### PR TITLE
Fix: performance 페이지 렌더링 오류 해결 및 성능 측정 도구 추가

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,10 +1,10 @@
 'use client';
-
 import About from '@/components/main/About';
 import { FadeInSection } from '@/components/main/FadeInSection';
 import Performance from '@/components/main/Performance';
 import Recruit from '@/components/main/Recruit';
 import Ticket from '@/components/main/Ticket';
+import { SpeedInsights } from '@vercel/speed-insights/next';
 
 export default function Home() {
   return (
@@ -21,6 +21,8 @@ export default function Home() {
       <div className="flex flex-col w-full h-auto justify-start items-center max-pad:px-[16px] bg-gray-90 bg-notice">
         <Recruit />
       </div>
+
+      <SpeedInsights />
     </div>
   );
 }

--- a/components/main/PerformanceCard.tsx
+++ b/components/main/PerformanceCard.tsx
@@ -12,7 +12,7 @@ const PerformanceCard: React.FC<SongProps> = ({ song }) => {
       <Image
         src={song.src}
         alt="thumbnail"
-        quality={80}
+        quality={60}
         className="rounded-[12px]"
       />
       <p className="text-[20px] pad:text-[22px] font-semibold mt-[8px] pad:mt-[12px]">

--- a/components/performance/Playlists.tsx
+++ b/components/performance/Playlists.tsx
@@ -159,7 +159,7 @@ const Playlists = () => {
               <Image
                 src={detail[0].src}
                 alt="thumbnail"
-                quality={80}
+                quality={50}
                 className="rounded-[12px]"
               />
             </div>
@@ -182,7 +182,7 @@ const Playlists = () => {
               <Image
                 src={detail[1].src}
                 alt="thumbnail"
-                quality={80}
+                quality={50}
                 className="rounded-[12px]"
               />
             </div>
@@ -205,7 +205,7 @@ const Playlists = () => {
               <Image
                 src={detail[2].src}
                 alt="thumbnail"
-                quality={80}
+                quality={50}
                 className="rounded-[12px]"
               />
             </div>
@@ -228,7 +228,7 @@ const Playlists = () => {
               <Image
                 src={detail[3].src}
                 alt="thumbnail"
-                quality={80}
+                quality={50}
                 className="rounded-[12px]"
               />
             </div>
@@ -251,7 +251,7 @@ const Playlists = () => {
               <Image
                 src={detail[4].src}
                 alt="thumbnail"
-                quality={80}
+                quality={50}
                 className="rounded-[12px]"
               />
             </div>
@@ -274,7 +274,7 @@ const Playlists = () => {
               <Image
                 src={detail[5].src}
                 alt="thumbnail"
-                quality={80}
+                quality={50}
                 className="rounded-[12px]"
               />
             </div>
@@ -297,7 +297,7 @@ const Playlists = () => {
               <Image
                 src={detail[6].src}
                 alt="thumbnail"
-                quality={80}
+                quality={50}
                 className="rounded-[12px]"
               />
             </div>
@@ -320,7 +320,7 @@ const Playlists = () => {
               <Image
                 src={detail[7].src}
                 alt="thumbnail"
-                quality={80}
+                quality={50}
                 className="rounded-[12px]"
               />
             </div>
@@ -343,7 +343,7 @@ const Playlists = () => {
               <Image
                 src={detail[8].src}
                 alt="thumbnail"
-                quality={80}
+                quality={50}
                 className="rounded-[12px]"
               />
             </div>
@@ -366,7 +366,7 @@ const Playlists = () => {
               <Image
                 src={detail[9].src}
                 alt="thumbnail"
-                quality={80}
+                quality={50}
                 className="rounded-[12px]"
               />
             </div>
@@ -389,7 +389,7 @@ const Playlists = () => {
               <Image
                 src={detail[10].src}
                 alt="thumbnail"
-                quality={80}
+                quality={50}
                 className="rounded-[12px]"
               />
             </div>
@@ -412,7 +412,7 @@ const Playlists = () => {
               <Image
                 src={detail[11].src}
                 alt="thumbnail"
-                quality={80}
+                quality={50}
                 className="rounded-[12px]"
               />
             </div>
@@ -436,7 +436,7 @@ const Playlists = () => {
                 <Image
                   src={detail[12].src}
                   alt="thumbnail"
-                  quality={80}
+                  quality={50}
                   className="rounded-[12px]"
                 />
               </div>
@@ -460,7 +460,7 @@ const Playlists = () => {
               <Image
                 src={detail[13].src}
                 alt="thumbnail"
-                quality={80}
+                quality={50}
                 className="rounded-[12px]"
               />
             </div>
@@ -483,7 +483,7 @@ const Playlists = () => {
               <Image
                 src={detail[13].src}
                 alt="thumbnail"
-                quality={80}
+                quality={50}
                 className="rounded-[12px]"
               />
             </div>
@@ -506,7 +506,7 @@ const Playlists = () => {
               <Image
                 src={detail[14].src}
                 alt="thumbnail"
-                quality={80}
+                quality={50}
                 className="rounded-[12px]"
               />
             </div>
@@ -529,7 +529,7 @@ const Playlists = () => {
               <Image
                 src={detail[14].src}
                 alt="thumbnail"
-                quality={80}
+                quality={50}
                 className="rounded-[12px]"
               />
             </div>

--- a/components/performance/YearSelector.tsx
+++ b/components/performance/YearSelector.tsx
@@ -101,10 +101,10 @@ const YearSelector = () => {
                   setSYear(year);
                   toggleBtn();
                 }}
-                className={`${sYear === year ? 'bg-primary-50' : 'bg-gray-0'} px-[12px] py-[4px] justify-center items-center gap-[10px] cursor-pointer rounded-[32px]`}
+                className={`${sYear === year ? 'bg-primary-50' : 'bg-gray-0'} px-[12px] py-[4px] flex justify-center items-center gap-[10px] cursor-pointer rounded-[32px]`}
               >
                 <p
-                  className={`${sYear === year ? 'text-gray-0' : 'text-gray-50'} w-[60px] justify-center items-center text-center font-pretendard text-base font-normal`}
+                  className={`${sYear === year ? 'text-gray-0' : 'text-gray-50'} w-[60px] justify-center flex items-center text-center font-pretendard text-base font-normal`}
                 >
                   {year}
                 </p>

--- a/components/performance/YearSelector.tsx
+++ b/components/performance/YearSelector.tsx
@@ -55,22 +55,24 @@ const YearSelector = () => {
                 </p>
               </div>
             ))
-          : currentYearList.slice(0, 1).map((year) => (
-              <div
-                key={year}
-                onClick={() => {
-                  setSYear(year);
-                }}
-                className={`${sYear === year ? 'bg-primary-50' : 'bg-gray-0'} " w-[84px] inline-flex px-[12px] py-[4px] justify-center items-center gap-[10px] rounded-[32px] cursor-pointer "`}
-              >
-                <p
+          : currentYearList
+              .filter((year) => year === sYear)
+              .map((year) => (
+                <div
                   key={year}
-                  className={`${sYear === year ? 'text-gray-0' : 'text-gray-50'} " text-center font-pretendard text-[16px] font-normal leading-6 "`}
+                  onClick={() => {
+                    setSYear(year);
+                  }}
+                  className={`${sYear === year ? 'bg-primary-50' : 'bg-gray-0'} " w-[84px] inline-flex px-[12px] py-[4px] justify-center items-center gap-[10px] rounded-[32px] border-primary-50 cursor-pointer "`}
                 >
-                  {year}
-                </p>
-              </div>
-            ))}
+                  <p
+                    key={year}
+                    className={`${sYear === year ? 'text-gray-0' : 'text-gray-50'} " text-center font-pretendard text-[16px] font-normal leading-6 "`}
+                  >
+                    {year}
+                  </p>
+                </div>
+              ))}
       </div>
 
       {/* 토글 버튼 */}

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@nextui-org/accordion": "^2.0.35",
         "@nextui-org/system": "^2.2.2",
         "@nextui-org/theme": "^2.2.6",
+        "@vercel/speed-insights": "^1.0.12",
         "axios": "^1.7.2",
         "framer-motion": "^11.2.13",
         "next": "^14.2.4",
@@ -2436,6 +2437,40 @@
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
       "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
       "dev": true
+    },
+    "node_modules/@vercel/speed-insights": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@vercel/speed-insights/-/speed-insights-1.0.12.tgz",
+      "integrity": "sha512-ZGQ+a7bcfWJD2VYEp2R1LHvRAMyyaFBYytZXsfnbOMkeOvzGNVxUL7aVUvisIrTZjXTSsxG45DKX7yiw6nq2Jw==",
+      "hasInstallScript": true,
+      "peerDependencies": {
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "react": "^18 || ^19",
+        "svelte": "^4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
+      }
     },
     "node_modules/acorn": {
       "version": "8.12.1",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@nextui-org/accordion": "^2.0.35",
     "@nextui-org/system": "^2.2.2",
     "@nextui-org/theme": "^2.2.6",
+    "@vercel/speed-insights": "^1.0.12",
     "axios": "^1.7.2",
     "framer-motion": "^11.2.13",
     "next": "^14.2.4",


### PR DESCRIPTION
## #️⃣연관된 이슈
> 

## 📝작업 내용
- performance 페이지 내부 YearSelector 정렬 수정하였습니다.
- performance 페이지 배열 렌더링 오류 해결하였습니다. 기존에 배열 slice 로 했던 방식에서 -> filter로 변경하여 선택한 연도만 화면에 렌더링 될 수 있도록 조정하였습니다.
- Vercel에서 배포 환경에서 사이트 성능 측정을 위해 Speed Insight를 추가하였습니다. 

## 🔎코드 설명 및 참고 사항
> 

## 💬리뷰 요구사항
>

## ⚠️로컬 실행 시 유의사항
 `npm install` 의존성 설치 후 사용 부탁드립니다.
