### PR TITLE
Feat: 공지사항 글쓰기 페이지 UI 구현 및 반응형

### DIFF
--- a/app/announcement/posting/page.tsx
+++ b/app/announcement/posting/page.tsx
@@ -1,0 +1,64 @@
+'use client';
+import React from 'react';
+
+const Page = () => {
+  return (
+    <div className="relative flex flex-col items-center mt-[96px] mb-[-160px] font-pretendard">
+      <section className="dt:w-[1200px] pad:w-[786px] ph:w-[328px] dt:pb-[578px] pad:pb-[559px] ph:pb-[171px]">
+        {/* 취소, 게시하기 */}
+        <div className="flex justify-end mb-10">
+          <div className="w-[51px] h-[46px] flex justify-center items-center rounded-[12px] mr-4 text-gray-40 text-[20px] font-[500] leading-[150%] cursor-pointer">
+            취소
+          </div>
+          <div className="w-[100px] h-[46px] flex justify-center items-center rounded-[12px] bg-gray-10 text-[20px] font-[500] leading-[150%] text-gray-0 cursor-pointer">
+            게시하기
+          </div>
+        </div>
+        {/* 제목 */}
+        <input
+          type="text"
+          placeholder="제목"
+          className="w-full pad:h-[64px] ph:h-[52px] shadow-[0_0_0_1px_black] rounded-[8px] px-3 py-2 pad:text-[32px] ph:text-[24px] font-[500] leading-[150%] text-black placeholder-gray-40
+          focus:shadow-outline focus:shadow-primary-50 focus:outline-none mb-10"
+        />
+        {/* 내용 */}
+        <textarea
+          placeholder="내용을 입력하세요"
+          className="w-full h-[586px] shadow-[0_0_0_1px_black] rounded-[8px] px-3 py-2 pad:text-[20px] ph:text-[16px] font-[500] leading-[150%] text-black placeholder-gray-40
+          focus:shadow-outline focus:shadow-primary-50 focus:outline-none resize-none mb-10"
+        />
+        {/* 첨부파일 업로드 */}
+        <p className="text-gray-90 text-[20px] font-[400] leading-normal pad:mb-2 ph:mb-4">
+          첨부파일 업로드<span className="ml-2">(0/5)</span>
+        </p>
+        <div className="w-full pad:h-[400px] ph:h-[328px] flex justify-center items-center mb-10">
+          <div className="pad:h-[400px] ph:h-[328px] pad:w-[400px] ph:w-[328px] shadow-[0_0_0_1px_black] rounded-[12px] flex justify-center items-center">
+            <div
+              className="w-8 h-8 rounded-full bg-gray-10 flex justify-center items-center cursor-pointer"
+              style={{ boxShadow: '0px 0px 4px rgba(0, 0, 0, 0.25)' }}
+            >
+              <span className="text-gray-0 text-[24px] font-[500] leading-normal pb-1">
+                +
+              </span>
+            </div>
+          </div>
+        </div>
+
+        {/* 커뮤니티 이용규칙 */}
+        <div className="bg-[#DADBE2] w-full h-[1px] mb-10" />
+        <p className="text-gray-40 pad:text-[20px] ph:text-[18px] font-[600] leading-normal mb-2">
+          커뮤니티 이용규칙
+        </p>
+        <p className="text-gray-40 pad:text-[16px] ph:text-[14px] font-[400] leading-normal">
+          ‘깔브리타임 게시판'은 깔루아 멤버 누구나 이용할 수 있는
+          커뮤니티입니다. 자유롭게 게시글을 작성하고 소통해주세요. 다만 누구나
+          기분 좋게 참여할 수 있는 커뮤니티를 만들기 위하여 관리자가 관리
+          운영하고 있습니다. 부적절한 언행 및 내용이 포함된 게시글을 관리자에
+          의해 경고없이 삭제될 수 있음을 알려드립니다.
+        </p>
+      </section>
+    </div>
+  );
+};
+
+export default Page;

--- a/app/announcement/posting/page.tsx
+++ b/app/announcement/posting/page.tsx
@@ -1,7 +1,12 @@
 'use client';
-import React from 'react';
+import React, { useState } from 'react';
 
 const Page = () => {
+  const [title, setTitle] = useState('');
+  const [content, setContent] = useState('');
+
+  const isPostActive = title.trim() !== '' && content.trim() !== '';
+
   return (
     <div className="relative flex flex-col items-center mt-[96px] mb-[-160px] font-pretendard">
       <section className="dt:w-[1200px] pad:w-[786px] ph:w-[328px] dt:pb-[578px] pad:pb-[559px] ph:pb-[171px]">
@@ -10,7 +15,9 @@ const Page = () => {
           <div className="w-[51px] h-[46px] flex justify-center items-center rounded-[12px] mr-4 text-gray-40 text-[20px] font-[500] leading-[150%] cursor-pointer">
             취소
           </div>
-          <div className="w-[100px] h-[46px] flex justify-center items-center rounded-[12px] bg-gray-10 text-[20px] font-[500] leading-[150%] text-gray-0 cursor-pointer">
+          <div
+            className={`w-[100px] h-[46px] flex justify-center items-center rounded-[12px] ${isPostActive ? 'bg-primary-50 cursor-pointer' : 'bg-gray-10 cursor-not-allowed'} text-[20px] font-[500] leading-[150%] text-gray-0`}
+          >
             게시하기
           </div>
         </div>
@@ -18,12 +25,16 @@ const Page = () => {
         <input
           type="text"
           placeholder="제목"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
           className="w-full pad:h-[64px] ph:h-[52px] shadow-[0_0_0_1px_black] rounded-[8px] px-3 py-2 pad:text-[32px] ph:text-[24px] font-[500] leading-[150%] text-black placeholder-gray-40
           focus:shadow-outline focus:shadow-primary-50 focus:outline-none mb-10"
         />
         {/* 내용 */}
         <textarea
           placeholder="내용을 입력하세요"
+          value={content}
+          onChange={(e) => setContent(e.target.value)}
           className="w-full h-[586px] shadow-[0_0_0_1px_black] rounded-[8px] px-3 py-2 pad:text-[20px] ph:text-[16px] font-[500] leading-[150%] text-black placeholder-gray-40
           focus:shadow-outline focus:shadow-primary-50 focus:outline-none resize-none mb-10"
         />

--- a/app/announcement/posting/page.tsx
+++ b/app/announcement/posting/page.tsx
@@ -1,4 +1,9 @@
 'use client';
+import CommunityRule from '@/components/announcement/posting/CommunityRule';
+import ContentInput from '@/components/announcement/posting/ContentInput';
+import ImageUpload from '@/components/announcement/posting/ImageUpload';
+import TitleInput from '@/components/announcement/posting/TitleInput';
+import TopButtons from '@/components/announcement/posting/TopButtons';
 import React, { useState } from 'react';
 
 const Page = () => {
@@ -10,63 +15,11 @@ const Page = () => {
   return (
     <div className="relative flex flex-col items-center mt-[96px] mb-[-160px] font-pretendard">
       <section className="dt:w-[1200px] pad:w-[786px] ph:w-[328px] dt:pb-[578px] pad:pb-[559px] ph:pb-[171px]">
-        {/* 취소, 게시하기 */}
-        <div className="flex justify-end mb-10">
-          <div className="w-[51px] h-[46px] flex justify-center items-center rounded-[12px] mr-4 text-gray-40 text-[20px] font-[500] leading-[150%] cursor-pointer">
-            취소
-          </div>
-          <div
-            className={`w-[100px] h-[46px] flex justify-center items-center rounded-[12px] ${isPostActive ? 'bg-primary-50 cursor-pointer' : 'bg-gray-10 cursor-not-allowed'} text-[20px] font-[500] leading-[150%] text-gray-0`}
-          >
-            게시하기
-          </div>
-        </div>
-        {/* 제목 */}
-        <input
-          type="text"
-          placeholder="제목"
-          value={title}
-          onChange={(e) => setTitle(e.target.value)}
-          className="w-full pad:h-[64px] ph:h-[52px] shadow-[0_0_0_1px_black] rounded-[8px] px-3 py-2 pad:text-[32px] ph:text-[24px] font-[500] leading-[150%] text-black placeholder-gray-40
-          focus:shadow-outline focus:shadow-primary-50 focus:outline-none mb-10"
-        />
-        {/* 내용 */}
-        <textarea
-          placeholder="내용을 입력하세요"
-          value={content}
-          onChange={(e) => setContent(e.target.value)}
-          className="w-full h-[586px] shadow-[0_0_0_1px_black] rounded-[8px] px-3 py-2 pad:text-[20px] ph:text-[16px] font-[500] leading-[150%] text-black placeholder-gray-40
-          focus:shadow-outline focus:shadow-primary-50 focus:outline-none resize-none mb-10"
-        />
-        {/* 첨부파일 업로드 */}
-        <p className="text-gray-90 text-[20px] font-[400] leading-normal pad:mb-2 ph:mb-4">
-          첨부파일 업로드<span className="ml-2">(0/5)</span>
-        </p>
-        <div className="w-full pad:h-[400px] ph:h-[328px] flex justify-center items-center mb-10">
-          <div className="pad:h-[400px] ph:h-[328px] pad:w-[400px] ph:w-[328px] shadow-[0_0_0_1px_black] rounded-[12px] flex justify-center items-center">
-            <div
-              className="w-8 h-8 rounded-full bg-gray-10 flex justify-center items-center cursor-pointer"
-              style={{ boxShadow: '0px 0px 4px rgba(0, 0, 0, 0.25)' }}
-            >
-              <span className="text-gray-0 text-[24px] font-[500] leading-normal pb-1">
-                +
-              </span>
-            </div>
-          </div>
-        </div>
-
-        {/* 커뮤니티 이용규칙 */}
-        <div className="bg-[#DADBE2] w-full h-[1px] mb-10" />
-        <p className="text-gray-40 pad:text-[20px] ph:text-[18px] font-[600] leading-normal mb-2">
-          커뮤니티 이용규칙
-        </p>
-        <p className="text-gray-40 pad:text-[16px] ph:text-[14px] font-[400] leading-normal">
-          ‘깔브리타임 게시판'은 깔루아 멤버 누구나 이용할 수 있는
-          커뮤니티입니다. 자유롭게 게시글을 작성하고 소통해주세요. 다만 누구나
-          기분 좋게 참여할 수 있는 커뮤니티를 만들기 위하여 관리자가 관리
-          운영하고 있습니다. 부적절한 언행 및 내용이 포함된 게시글을 관리자에
-          의해 경고없이 삭제될 수 있음을 알려드립니다.
-        </p>
+        <TopButtons isPostActive={isPostActive} />
+        <TitleInput title={title} setTitle={setTitle} />
+        <ContentInput content={content} setContent={setContent} />
+        <ImageUpload />
+        <CommunityRule />
       </section>
     </div>
   );

--- a/app/globals.css
+++ b/app/globals.css
@@ -63,3 +63,22 @@ body {
     animation-play-state: paused;
   }
 }
+
+.image-upload-scrollbar::-webkit-scrollbar {
+  height: 6px;
+}
+
+.image-upload-scrollbar::-webkit-scrollbar-track {
+  background-color: white;
+  border-radius: 99px;
+  border: 1px solid #cbcdd7;
+}
+
+.image-upload-scrollbar::-webkit-scrollbar-thumb {
+  background: #cbcdd7;
+  border-radius: 99px;
+}
+
+.image-upload-scrollbar::-webkit-scrollbar-thumb:hover {
+  background: #aeb1c1; /* 호버 시 */
+}

--- a/components/announcement/posting/CancelPopup.tsx
+++ b/components/announcement/posting/CancelPopup.tsx
@@ -39,22 +39,13 @@ const CancelPopup: React.FC<CancelPopupProps> = ({ onClose, onConfirm }) => {
             onClick={onClose}
           />
         </div>
-        <div className="pad:mt-[107px] ph:mt-[52px] pad:text-[22px] ph:text-[16px] font-[500] leading-[150%] text-[black]">
-          <div className="ph:hidden pad:block">
-            <p>게시글 작성을 취소하시겠습니까?</p>
-            <p>취소 시 작성하던 게시글은 저장되지 않습니다.</p>
-          </div>
-
-          {/* ph */}
-          <div className="pad:hidden ph:block">
-            <p>게시글 작성을 취소하시겠습니까?</p>
-            <p>취소 시 작성하던 게시글은</p>
-            <p>저장되지 않습니다.</p>
-          </div>
+        <div className="mx-[55px] pad:mt-[107px] ph:mt-[52px] pad:text-[22px] ph:text-[16px] font-[500] text-[black]">
+          <p>게시글 작성을 취소하시겠습니까?</p>
+          <p>취소 시 작성하던 게시글은 저장되지 않습니다.</p>
         </div>
         <div
           onClick={onConfirm}
-          className="w-full cursor-pointer flex justify-center items-center pad:h-16 ph:h-[60px] pad:mt-16 ph:mt-[41px] text-center bg-danger-50 text-gray-0 pad:text-[22px] ph:text-[18px] font-[600] leading-[150%]"
+          className="w-full cursor-pointer flex justify-center items-center pad:h-16 ph:h-[60px] pad:mt-16 ph:mt-[41px] text-center bg-danger-50 text-gray-0 pad:text-[22px] ph:text-[18px] font-[600]"
         >
           취소하기
         </div>

--- a/components/announcement/posting/CancelPopup.tsx
+++ b/components/announcement/posting/CancelPopup.tsx
@@ -39,7 +39,7 @@ const CancelPopup: React.FC<CancelPopupProps> = ({ onClose, onConfirm }) => {
             onClick={onClose}
           />
         </div>
-        <div className="pad:mt-[107px] ph:mt-[52px] pad:text-[22px] ph:text-[16px] font-[500] leading-[150%] text-black">
+        <div className="pad:mt-[107px] ph:mt-[52px] pad:text-[22px] ph:text-[16px] font-[500] leading-[150%] text-[black]">
           <div className="ph:hidden pad:block">
             <p>게시글 작성을 취소하시겠습니까?</p>
             <p>취소 시 작성하던 게시글은 저장되지 않습니다.</p>

--- a/components/announcement/posting/CancelPopup.tsx
+++ b/components/announcement/posting/CancelPopup.tsx
@@ -1,0 +1,66 @@
+import React, { useEffect } from 'react';
+import Image from 'next/image';
+
+interface CancelPopupProps {
+  onClose: () => void;
+  onConfirm: () => void;
+}
+
+const CancelPopup: React.FC<CancelPopupProps> = ({ onClose, onConfirm }) => {
+  // 모달 열릴 때 스크롤 막기
+  useEffect(() => {
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.body.style.overflow = ''; // 모달이 닫힐 때 스크롤 복구
+    };
+  }, []);
+
+  // 모달 바깥 클릭 시
+  const handleOverlayClick = (
+    event: React.MouseEvent<HTMLDivElement, MouseEvent>
+  ) => {
+    if (event.target === event.currentTarget) {
+      onClose();
+    }
+  };
+
+  return (
+    <div
+      onClick={handleOverlayClick}
+      className="fixed z-50 top-0 left-0 right-0 bottom-0 bg-[#0000008a] flex justify-center items-center"
+    >
+      <div className="fixed bg-[white] overflow-hidden rounded-[24px] pad:w-[600px] ph:w-[328px] pad:h-[300px] ph:h-[224px] flex flex-col items-center text-center">
+        <div className="absolute top-6 right-10 cursor-pointer">
+          <Image
+            src="/image/black_x.svg"
+            width={24}
+            height={24}
+            alt="X"
+            onClick={onClose}
+          />
+        </div>
+        <div className="pad:mt-[107px] ph:mt-[52px] pad:text-[22px] ph:text-[16px] font-[500] leading-[150%] text-black">
+          <div className="ph:hidden pad:block">
+            <p>게시글 작성을 취소하시겠습니까?</p>
+            <p>취소 시 작성하던 게시글은 저장되지 않습니다.</p>
+          </div>
+
+          {/* ph */}
+          <div className="pad:hidden ph:block">
+            <p>게시글 작성을 취소하시겠습니까?</p>
+            <p>취소 시 작성하던 게시글은</p>
+            <p>저장되지 않습니다.</p>
+          </div>
+        </div>
+        <div
+          onClick={onConfirm}
+          className="w-full cursor-pointer flex justify-center items-center pad:h-16 ph:h-[60px] pad:mt-16 ph:mt-[41px] text-center bg-danger-50 text-gray-0 pad:text-[22px] ph:text-[18px] font-[600] leading-[150%]"
+        >
+          취소하기
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default CancelPopup;

--- a/components/announcement/posting/CommunityRule.tsx
+++ b/components/announcement/posting/CommunityRule.tsx
@@ -1,0 +1,19 @@
+const CommunityRule = () => {
+  return (
+    <>
+      <div className="bg-[#DADBE2] w-full h-[1px] mb-10" />
+      <p className="text-gray-40 pad:text-[20px] ph:text-[18px] font-[600] leading-normal mb-2">
+        커뮤니티 이용규칙
+      </p>
+      <p className="text-gray-40 pad:text-[16px] ph:text-[14px] font-[400] leading-normal">
+        ‘깔브리타임 게시판'은 깔루아 멤버 누구나 이용할 수 있는 커뮤니티입니다.
+        자유롭게 게시글을 작성하고 소통해주세요. 다만 누구나 기분 좋게 참여할 수
+        있는 커뮤니티를 만들기 위하여 관리자가 관리 운영하고 있습니다. 부적절한
+        언행 및 내용이 포함된 게시글을 관리자에 의해 경고없이 삭제될 수 있음을
+        알려드립니다.
+      </p>
+    </>
+  );
+};
+
+export default CommunityRule;

--- a/components/announcement/posting/ContentInput.tsx
+++ b/components/announcement/posting/ContentInput.tsx
@@ -10,7 +10,7 @@ const ContentInput: React.FC<ContentInputProps> = ({ content, setContent }) => (
     placeholder="내용을 입력하세요"
     value={content}
     onChange={(e) => setContent(e.target.value)}
-    className="w-full h-[586px] rounded-[8px] px-3 py-2 pad:text-[20px] ph:text-[16px] font-[500] leading-[150%] text-black placeholder-gray-40
+    className="w-full h-[586px] rounded-[8px] px-3 py-2 pad:text-[20px] ph:text-[16px] font-[500] leading-[150%] text-[black] placeholder-gray-40
     focus:shadow-outline focus:shadow-primary-50 focus:outline-none resize-none mb-10"
     style={{ boxShadow: 'inset 0 0 0 1px rgba(0, 0, 0, 1)' }}
   />

--- a/components/announcement/posting/ContentInput.tsx
+++ b/components/announcement/posting/ContentInput.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+interface ContentInputProps {
+  content: string;
+  setContent: (value: string) => void;
+}
+
+const ContentInput: React.FC<ContentInputProps> = ({ content, setContent }) => (
+  <textarea
+    placeholder="내용을 입력하세요"
+    value={content}
+    onChange={(e) => setContent(e.target.value)}
+    className="w-full h-[586px] shadow-[0_0_0_1px_black] rounded-[8px] px-3 py-2 pad:text-[20px] ph:text-[16px] font-[500] leading-[150%] text-black placeholder-gray-40
+    focus:shadow-outline focus:shadow-primary-50 focus:outline-none resize-none mb-10"
+  />
+);
+
+export default ContentInput;

--- a/components/announcement/posting/ContentInput.tsx
+++ b/components/announcement/posting/ContentInput.tsx
@@ -10,7 +10,7 @@ const ContentInput: React.FC<ContentInputProps> = ({ content, setContent }) => (
     placeholder="내용을 입력하세요"
     value={content}
     onChange={(e) => setContent(e.target.value)}
-    className="w-full h-[586px] rounded-[8px] px-3 py-2 pad:text-[20px] ph:text-[16px] font-[500] leading-[150%] text-[black] placeholder-gray-40
+    className="w-full h-[586px] rounded-[8px] px-3 py-2 pad:text-[20px] ph:text-[16px] font-[500] text-[black] placeholder-gray-40
     focus:shadow-outline focus:shadow-primary-50 focus:outline-none resize-none mb-10"
     style={{ boxShadow: 'inset 0 0 0 1px rgba(0, 0, 0, 1)' }}
   />

--- a/components/announcement/posting/ContentInput.tsx
+++ b/components/announcement/posting/ContentInput.tsx
@@ -10,8 +10,9 @@ const ContentInput: React.FC<ContentInputProps> = ({ content, setContent }) => (
     placeholder="내용을 입력하세요"
     value={content}
     onChange={(e) => setContent(e.target.value)}
-    className="w-full h-[586px] shadow-[0_0_0_1px_black] rounded-[8px] px-3 py-2 pad:text-[20px] ph:text-[16px] font-[500] leading-[150%] text-black placeholder-gray-40
+    className="w-full h-[586px] rounded-[8px] px-3 py-2 pad:text-[20px] ph:text-[16px] font-[500] leading-[150%] text-black placeholder-gray-40
     focus:shadow-outline focus:shadow-primary-50 focus:outline-none resize-none mb-10"
+    style={{ boxShadow: 'inset 0 0 0 1px rgba(0, 0, 0, 1)' }}
   />
 );
 

--- a/components/announcement/posting/ImageUpload.tsx
+++ b/components/announcement/posting/ImageUpload.tsx
@@ -1,22 +1,91 @@
+import React, { useEffect, useRef, useState } from 'react';
+
 const ImageUpload = () => {
+  const [images, setImages] = useState<string[]>([]);
+  const [hasScrollbar, setHasScrollbar] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const handleImageUpload = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const files = event.target.files;
+    if (files) {
+      const newImages = Array.from(files).map(
+        (file) => URL.createObjectURL(file) // 이미지 미리 볼 수 있게
+      );
+      setImages((prevImages) => [...prevImages, ...newImages]);
+    }
+  };
+
+  // 스크롤바 유무 감지
+  useEffect(() => {
+    const checkScrollbar = () => {
+      if (containerRef.current) {
+        const hasScroll =
+          containerRef.current.scrollWidth > containerRef.current.clientWidth;
+        setHasScrollbar(hasScroll);
+      }
+    };
+
+    checkScrollbar();
+
+    // 이미지가 변경될 때마다 스크롤바 상태 확인
+    window.addEventListener('resize', checkScrollbar);
+    return () => window.removeEventListener('resize', checkScrollbar);
+  }, [images]);
+
   return (
-    <>
+    <div className="mb-10">
       <p className="text-gray-90 text-[20px] font-[400] leading-normal pad:mb-2 ph:mb-4">
-        첨부파일 업로드<span className="ml-2">(0/5)</span>
+        첨부파일 업로드<span className="ml-2">({images.length}/5)</span>
       </p>
-      <div className="w-full pad:h-[400px] ph:h-[328px] flex justify-center items-center mb-10">
-        <div className="pad:h-[400px] ph:h-[328px] pad:w-[400px] ph:w-[328px] shadow-[0_0_0_1px_black] rounded-[12px] flex justify-center items-center">
-          <div
-            className="w-8 h-8 rounded-full bg-gray-10 flex justify-center items-center cursor-pointer"
-            style={{ boxShadow: '0px 0px 4px rgba(0, 0, 0, 0.25)' }}
-          >
-            <span className="text-gray-0 text-[24px] font-[500] leading-normal pb-1">
-              +
-            </span>
-          </div>
+
+      {/* container */}
+      <div ref={containerRef} className="mt-2 overflow-x-auto w-full">
+        <div
+          className={`flex ${
+            images.length === 0 ? 'justify-center' : 'space-x-4'
+          } ${hasScrollbar ? 'pb-[10px]' : ''}`}
+        >
+          {/* 이미지 */}
+          {images.map((image, index) => (
+            <div
+              key={index}
+              className="pad:w-[300px] ph:w-[234px] pad:h-[400px] ph:h-[328px] rounded-[12px] flex justify-center items-center overflow-hidden flex-shrink-0"
+              style={{ boxShadow: 'inset 0 0 0 1px rgba(0, 0, 0, 1)' }}
+            >
+              <img
+                src={image}
+                alt={`uploaded-${index}`}
+                className="pad:w-[298px] ph:w-[232px] pad:h-[398px] ph:h-[326px] object-cover rounded-[11px]"
+              />
+            </div>
+          ))}
+
+          {/* 추가버튼 box */}
+          {images.length < 5 && (
+            <label
+              className="pad:w-[400px] ph:w-[328px] pad:h-[400px] ph:h-[328px] rounded-[12px] flex justify-center items-center cursor-pointer flex-shrink-0"
+              style={{ boxShadow: 'inset 0 0 0 1px rgba(0, 0, 0, 1)' }}
+            >
+              <input
+                type="file"
+                multiple
+                accept="image/*"
+                onChange={handleImageUpload}
+                className="hidden"
+              />
+              <div
+                className="w-8 h-8 rounded-full bg-gray-10 flex justify-center items-center"
+                style={{ boxShadow: '0px 0px 4px rgba(0, 0, 0, 0.25)' }}
+              >
+                <span className="text-gray-0 text-[24px] font-[500] leading-normal pb-1">
+                  +
+                </span>
+              </div>
+            </label>
+          )}
         </div>
       </div>
-    </>
+    </div>
   );
 };
 

--- a/components/announcement/posting/ImageUpload.tsx
+++ b/components/announcement/posting/ImageUpload.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 
 const ImageUpload = () => {
   const [images, setImages] = useState<string[]>([]);
@@ -31,6 +31,15 @@ const ImageUpload = () => {
     }
   };
 
+  // 이미지가 추가될 때마다 오른쪽으로 스크롤 이동
+  useEffect(() => {
+    if (hasScrollbar && containerRef.current) {
+      setTimeout(() => {
+        containerRef.current!.scrollLeft = containerRef.current!.scrollWidth;
+      }, 20);
+    }
+  }, [images, hasScrollbar]);
+
   return (
     <div className="mb-10">
       <p className="text-gray-90 text-[20px] font-[400] leading-normal pad:mb-2 ph:mb-4">
@@ -38,7 +47,10 @@ const ImageUpload = () => {
       </p>
 
       {/* container */}
-      <div ref={containerRef} className="mt-2 overflow-x-auto w-full">
+      <div
+        ref={containerRef}
+        className="mt-2 overflow-x-auto w-full image-upload-scrollbar"
+      >
         <div
           className={`flex ${
             images.length === 0 ? 'justify-center' : 'space-x-4'

--- a/components/announcement/posting/ImageUpload.tsx
+++ b/components/announcement/posting/ImageUpload.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useRef, useState } from 'react';
 
 const ImageUpload = () => {
   const [images, setImages] = useState<string[]>([]);
@@ -13,6 +13,7 @@ const ImageUpload = () => {
         (file) => URL.createObjectURL(file) // 이미지 미리 볼 수 있게
       );
       setImages((prevImages) => [...prevImages, ...newImages]);
+      setTimeout(checkScrollbar, 20);
     }
   };
 
@@ -21,22 +22,14 @@ const ImageUpload = () => {
     setImages((prevImages) => prevImages.filter((_, i) => i !== index));
   };
 
-  // 스크롤바 유무 감지
-  useEffect(() => {
-    const checkScrollbar = () => {
-      if (containerRef.current) {
-        const hasScroll =
-          containerRef.current.scrollWidth > containerRef.current.clientWidth;
-        setHasScrollbar(hasScroll);
-      }
-    };
-
-    checkScrollbar();
-
-    // 이미지가 변경될 때마다 스크롤바 상태 확인
-    window.addEventListener('resize', checkScrollbar);
-    return () => window.removeEventListener('resize', checkScrollbar);
-  }, [images]);
+  // 스크롤바 유무 감지 함수
+  const checkScrollbar = () => {
+    if (containerRef.current) {
+      const hasScroll =
+        containerRef.current.scrollWidth > containerRef.current.clientWidth;
+      setHasScrollbar(hasScroll);
+    }
+  };
 
   return (
     <div className="mb-10">
@@ -55,16 +48,16 @@ const ImageUpload = () => {
           {images.map((image, index) => (
             <div
               key={index}
-              className="pad:w-[300px] ph:w-[234px] pad:h-[400px] ph:h-[328px] rounded-[12px] flex justify-center items-center overflow-hidden flex-shrink-0 group"
+              className="relative pad:h-[400px] ph:h-[328px] rounded-[12px] flex justify-center items-center overflow-hidden flex-shrink-0 group"
             >
               <img
                 src={image}
                 alt={`uploaded-${index}`}
-                className="relative w-full h-full object-cover rounded-[11px] transition duration-200 ease-in-out group-hover:blur-sm"
+                className="w-auto h-full object-cover rounded-[11px] transition duration-200 ease-in-out group-hover:blur-sm"
               />
 
               {/* Hover 시 blur 및 삭제 버튼 */}
-              <div className="absolute pad:w-[300px] ph:w-[234px] pad:h-[400px] ph:h-[328px] bg-[black]/50 rounded-[11px] opacity-0 group-hover:opacity-100 transition-opacity duration-200 flex items-center justify-center">
+              <div className="absolute top-0 left-0 h-full w-full pad:h-[400px] ph:h-[328px] bg-[black]/50 rounded-[11px] opacity-0 group-hover:opacity-100 transition-opacity duration-200 flex items-center justify-center">
                 <button
                   onClick={() => handleImageDelete(index)}
                   className="w-8 h-8 rounded-full bg-danger-40 text-[white] text-[24px] font-[500] flex items-center justify-center mb-1"

--- a/components/announcement/posting/ImageUpload.tsx
+++ b/components/announcement/posting/ImageUpload.tsx
@@ -5,6 +5,7 @@ const ImageUpload = () => {
   const [hasScrollbar, setHasScrollbar] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
 
+  // 이미지 추가
   const handleImageUpload = (event: React.ChangeEvent<HTMLInputElement>) => {
     const files = event.target.files;
     if (files) {
@@ -13,6 +14,11 @@ const ImageUpload = () => {
       );
       setImages((prevImages) => [...prevImages, ...newImages]);
     }
+  };
+
+  // 이미지 삭제
+  const handleImageDelete = (index: number) => {
+    setImages((prevImages) => prevImages.filter((_, i) => i !== index));
   };
 
   // 스크롤바 유무 감지
@@ -49,18 +55,27 @@ const ImageUpload = () => {
           {images.map((image, index) => (
             <div
               key={index}
-              className="pad:w-[300px] ph:w-[234px] pad:h-[400px] ph:h-[328px] rounded-[12px] flex justify-center items-center overflow-hidden flex-shrink-0"
-              style={{ boxShadow: 'inset 0 0 0 1px rgba(0, 0, 0, 1)' }}
+              className="pad:w-[300px] ph:w-[234px] pad:h-[400px] ph:h-[328px] rounded-[12px] flex justify-center items-center overflow-hidden flex-shrink-0 group"
             >
               <img
                 src={image}
                 alt={`uploaded-${index}`}
-                className="pad:w-[298px] ph:w-[232px] pad:h-[398px] ph:h-[326px] object-cover rounded-[11px]"
+                className="relative w-full h-full object-cover rounded-[11px] transition duration-200 ease-in-out group-hover:blur-sm"
               />
+
+              {/* Hover 시 blur 및 삭제 버튼 */}
+              <div className="absolute pad:w-[300px] ph:w-[234px] pad:h-[400px] ph:h-[328px] bg-[black]/50 rounded-[11px] opacity-0 group-hover:opacity-100 transition-opacity duration-200 flex items-center justify-center">
+                <button
+                  onClick={() => handleImageDelete(index)}
+                  className="w-8 h-8 rounded-full bg-danger-40 text-[white] text-[24px] font-[500] flex items-center justify-center mb-1"
+                >
+                  -
+                </button>
+              </div>
             </div>
           ))}
 
-          {/* 추가버튼 box */}
+          {/* 추가 버튼 box */}
           {images.length < 5 && (
             <label
               className="pad:w-[400px] ph:w-[328px] pad:h-[400px] ph:h-[328px] rounded-[12px] flex justify-center items-center cursor-pointer flex-shrink-0"

--- a/components/announcement/posting/ImageUpload.tsx
+++ b/components/announcement/posting/ImageUpload.tsx
@@ -1,0 +1,23 @@
+const ImageUpload = () => {
+  return (
+    <>
+      <p className="text-gray-90 text-[20px] font-[400] leading-normal pad:mb-2 ph:mb-4">
+        첨부파일 업로드<span className="ml-2">(0/5)</span>
+      </p>
+      <div className="w-full pad:h-[400px] ph:h-[328px] flex justify-center items-center mb-10">
+        <div className="pad:h-[400px] ph:h-[328px] pad:w-[400px] ph:w-[328px] shadow-[0_0_0_1px_black] rounded-[12px] flex justify-center items-center">
+          <div
+            className="w-8 h-8 rounded-full bg-gray-10 flex justify-center items-center cursor-pointer"
+            style={{ boxShadow: '0px 0px 4px rgba(0, 0, 0, 0.25)' }}
+          >
+            <span className="text-gray-0 text-[24px] font-[500] leading-normal pb-1">
+              +
+            </span>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default ImageUpload;

--- a/components/announcement/posting/TitleInput.tsx
+++ b/components/announcement/posting/TitleInput.tsx
@@ -11,7 +11,7 @@ const TitleInput: React.FC<TitleInputProps> = ({ title, setTitle }) => (
     placeholder="제목"
     value={title}
     onChange={(e) => setTitle(e.target.value)}
-    className="w-full pad:h-[64px] ph:h-[52px] rounded-[8px] px-3 py-2 pad:text-[32px] ph:text-[24px] font-[500] leading-[150%] text-[black] placeholder-gray-40
+    className="w-full pad:h-[64px] ph:h-[52px] rounded-[8px] px-3 py-2 pad:text-[32px] ph:text-[24px] font-[500] text-[black] placeholder-gray-40
     focus:shadow-outline focus:shadow-primary-50 focus:outline-none mb-10"
     style={{ boxShadow: 'inset 0 0 0 1px rgba(0, 0, 0, 1)' }}
   />

--- a/components/announcement/posting/TitleInput.tsx
+++ b/components/announcement/posting/TitleInput.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+
+interface TitleInputProps {
+  title: string;
+  setTitle: (value: string) => void;
+}
+
+const TitleInput: React.FC<TitleInputProps> = ({ title, setTitle }) => (
+  <input
+    type="text"
+    placeholder="제목"
+    value={title}
+    onChange={(e) => setTitle(e.target.value)}
+    className="w-full pad:h-[64px] ph:h-[52px] shadow-[0_0_0_1px_black] rounded-[8px] px-3 py-2 pad:text-[32px] ph:text-[24px] font-[500] leading-[150%] text-black placeholder-gray-40
+    focus:shadow-outline focus:shadow-primary-50 focus:outline-none mb-10"
+  />
+);
+
+export default TitleInput;

--- a/components/announcement/posting/TitleInput.tsx
+++ b/components/announcement/posting/TitleInput.tsx
@@ -11,7 +11,7 @@ const TitleInput: React.FC<TitleInputProps> = ({ title, setTitle }) => (
     placeholder="제목"
     value={title}
     onChange={(e) => setTitle(e.target.value)}
-    className="w-full pad:h-[64px] ph:h-[52px] rounded-[8px] px-3 py-2 pad:text-[32px] ph:text-[24px] font-[500] leading-[150%] text-black placeholder-gray-40
+    className="w-full pad:h-[64px] ph:h-[52px] rounded-[8px] px-3 py-2 pad:text-[32px] ph:text-[24px] font-[500] leading-[150%] text-[black] placeholder-gray-40
     focus:shadow-outline focus:shadow-primary-50 focus:outline-none mb-10"
     style={{ boxShadow: 'inset 0 0 0 1px rgba(0, 0, 0, 1)' }}
   />

--- a/components/announcement/posting/TitleInput.tsx
+++ b/components/announcement/posting/TitleInput.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React from 'react';
 
 interface TitleInputProps {
   title: string;
@@ -11,8 +11,9 @@ const TitleInput: React.FC<TitleInputProps> = ({ title, setTitle }) => (
     placeholder="제목"
     value={title}
     onChange={(e) => setTitle(e.target.value)}
-    className="w-full pad:h-[64px] ph:h-[52px] shadow-[0_0_0_1px_black] rounded-[8px] px-3 py-2 pad:text-[32px] ph:text-[24px] font-[500] leading-[150%] text-black placeholder-gray-40
+    className="w-full pad:h-[64px] ph:h-[52px] rounded-[8px] px-3 py-2 pad:text-[32px] ph:text-[24px] font-[500] leading-[150%] text-black placeholder-gray-40
     focus:shadow-outline focus:shadow-primary-50 focus:outline-none mb-10"
+    style={{ boxShadow: 'inset 0 0 0 1px rgba(0, 0, 0, 1)' }}
   />
 );
 

--- a/components/announcement/posting/TopButtons.tsx
+++ b/components/announcement/posting/TopButtons.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+interface TopButtonsProps {
+  isPostActive: boolean;
+}
+
+const TopButtons: React.FC<TopButtonsProps> = ({ isPostActive }) => {
+  return (
+    <div className="flex justify-end mb-10">
+      <div className="w-[51px] h-[46px] flex justify-center items-center rounded-[12px] mr-4 text-gray-40 text-[20px] font-[500] leading-[150%] cursor-pointer">
+        취소
+      </div>
+      <div
+        className={`w-[100px] h-[46px] flex justify-center items-center rounded-[12px] ${
+          isPostActive
+            ? 'bg-primary-50 cursor-pointer'
+            : 'bg-gray-10 cursor-not-allowed'
+        } text-[20px] font-[500] leading-[150%] text-gray-0`}
+      >
+        게시하기
+      </div>
+    </div>
+  );
+};
+
+export default TopButtons;

--- a/components/announcement/posting/TopButtons.tsx
+++ b/components/announcement/posting/TopButtons.tsx
@@ -29,7 +29,7 @@ const TopButtons: React.FC<TopButtonsProps> = ({ isPostActive }) => {
       <div className="flex justify-end mb-10">
         <div
           onClick={handleCancelClick}
-          className="w-[51px] h-[46px] flex justify-center items-center rounded-[12px] mr-4 text-gray-40 text-[20px] font-[500] leading-[150%] cursor-pointer"
+          className="w-[51px] h-[46px] flex justify-center items-center rounded-[12px] mr-4 text-gray-40 text-[20px] font-[500] cursor-pointer"
         >
           취소
         </div>
@@ -38,7 +38,7 @@ const TopButtons: React.FC<TopButtonsProps> = ({ isPostActive }) => {
             isPostActive
               ? 'bg-primary-50 cursor-pointer'
               : 'bg-gray-10 cursor-not-allowed'
-          } text-[20px] font-[500] leading-[150%] text-gray-0`}
+          } text-[20px] font-[500] text-gray-0`}
         >
           게시하기
         </div>

--- a/components/announcement/posting/TopButtons.tsx
+++ b/components/announcement/posting/TopButtons.tsx
@@ -1,25 +1,55 @@
-import React from 'react';
+'use client';
+import React, { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import CancelPopup from '@/components/announcement/posting/CancelPopup';
 
 interface TopButtonsProps {
   isPostActive: boolean;
 }
 
 const TopButtons: React.FC<TopButtonsProps> = ({ isPostActive }) => {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const router = useRouter();
+
+  const handleCancelClick = () => {
+    setIsModalOpen(true);
+  };
+
+  const handleModalClose = () => {
+    setIsModalOpen(false);
+  };
+
+  const handleModalConfirm = () => {
+    router.back();
+    setIsModalOpen(false);
+  };
+
   return (
-    <div className="flex justify-end mb-10">
-      <div className="w-[51px] h-[46px] flex justify-center items-center rounded-[12px] mr-4 text-gray-40 text-[20px] font-[500] leading-[150%] cursor-pointer">
-        취소
+    <>
+      <div className="flex justify-end mb-10">
+        <div
+          onClick={handleCancelClick}
+          className="w-[51px] h-[46px] flex justify-center items-center rounded-[12px] mr-4 text-gray-40 text-[20px] font-[500] leading-[150%] cursor-pointer"
+        >
+          취소
+        </div>
+        <div
+          className={`w-[100px] h-[46px] flex justify-center items-center rounded-[12px] ${
+            isPostActive
+              ? 'bg-primary-50 cursor-pointer'
+              : 'bg-gray-10 cursor-not-allowed'
+          } text-[20px] font-[500] leading-[150%] text-gray-0`}
+        >
+          게시하기
+        </div>
       </div>
-      <div
-        className={`w-[100px] h-[46px] flex justify-center items-center rounded-[12px] ${
-          isPostActive
-            ? 'bg-primary-50 cursor-pointer'
-            : 'bg-gray-10 cursor-not-allowed'
-        } text-[20px] font-[500] leading-[150%] text-gray-0`}
-      >
-        게시하기
-      </div>
-    </div>
+      {isModalOpen && (
+        <CancelPopup
+          onClose={handleModalClose}
+          onConfirm={handleModalConfirm}
+        />
+      )}
+    </>
   );
 };
 


### PR DESCRIPTION
## 📝작업 내용
> 1. announcement/posting 페이지 UI 구현 및 반응형 완료하였습니다.
> 2. 취소 버튼 클릭 시 CancelPopup이 뜨고, 팝업 바깥 스크롤 막았습니다.
> 3. 이미지 업로드 5장까지 가능하게 하고 height는 고정, width는 사진 비율에 맞게 달라지게 하였습니다.
> 4. 이미지 업로드 5장 이상은 + box 안 보이게 하였습니다.
> 5. 이미지 hover 시 블러와 - 버튼이 뜨고, - 버튼 누르면 삭제됩니다.
> 6. scrollbar는 image-upload-scrollbar로 커스텀하여 globals.css에 추가하였습니다.
> 7. 이미지 업로드 시 scrollbar가 가장 오른쪽으로 가도록 하였습니다.
> 8. 게시하기 버튼은 제목과 content가 입력되어야 활성화됩니다.

## 📸작동 화면
> ## 글 쓰기

https://github.com/user-attachments/assets/19379b06-c76d-4c66-b266-e6d8f023393f

> ## 사진 추가

https://github.com/user-attachments/assets/9ffed4bb-f4ca-4ff3-8d61-41a752481c1a

> ## 사진 삭제

https://github.com/user-attachments/assets/e4fd0396-a20e-49d5-8b4e-9f7c13b8b782

> ## 반응형 : tab

https://github.com/user-attachments/assets/891f1337-ea3c-4d13-bead-a1607969b5c2

> ## 반응형 : ph

https://github.com/user-attachments/assets/71418536-b111-4075-945b-c0fcba78a5d3



## 🔎코드 설명 및 참고 사항
> components/announcement/posting에 컴포넌트 각각 분리하였습니다.

## 💬리뷰 요구사항
> 피드백 환영 🙌 🩷

## ⚠️로컬 실행 시 유의사항
> X
