### PR TITLE
Feat: 글 수정버튼 페이지 및 내용 연결

### DIFF
--- a/app/(kahlua)/announcement/post/page.tsx
+++ b/app/(kahlua)/announcement/post/page.tsx
@@ -1,6 +1,5 @@
 'use client';
 import React, { useState } from 'react';
-import { v4 as uuidv4 } from 'uuid';
 import CommentList from '@/components/notice/CommentList';
 import Image from 'next/image';
 import arrow from '@/public/image/notice/Left.svg';
@@ -17,9 +16,9 @@ import {
 } from '@/components/util/noticeUtils';
 
 const Page = () => {
-  const noticeData = {
+  const [data, setData] = useState({
     title: '❗️깔루아 9월 정기공연❗️',
-    text: `안녕하세요 깔루아 21기 기장 최승원입니다🤩
+    content: `안녕하세요 깔루아 21기 기장 최승원입니다🤩
 9월 1일 금요일, 깔루아의 9월 정기공연이 있습니다‼️
 재학생이신 선배님들께서는 수업이 끝난 후에, 졸업생이신 선배님들께서는 시간이 되신다면 공연 보러오셔서 함께 즐겨주시면 좋을 것 같습니다 !!
 
@@ -36,9 +35,16 @@ const Page = () => {
 혹시 공연에 참석하시는 선배님들이나, 뒷풀이에 참석하시는 선배님들께서는 010-4827-2589로 연락주시면 감사하겠습니다🤩
 
 기타 모든 문의사항은 페이스북 메세지나 댓글, 또는 위의 전화번호로 연락주세요 ! 감사합니다🤩🤩`,
-    author: '관리자',
+    user: '관리자',
     date: '2024. 08. 01',
-  };
+    imageUrls: [
+      'https://i.ibb.co/hypZvxt/IMG-3791.jpg',
+      'https://i.ibb.co/hypZvxt/IMG-3791.jpg',
+      'https://i.ibb.co/hypZvxt/IMG-3791.jpg',
+      'https://i.ibb.co/hypZvxt/IMG-3791.jpg',
+      'https://i.ibb.co/hypZvxt/IMG-3791.jpg',
+    ],
+  });
 
   const [chatCount, setChatCount] = useState(0);
   const [replyingToId, setReplyingToId] = useState<string | null>(null);
@@ -71,7 +77,10 @@ const Page = () => {
     <div className="flex flex-col items-center justify-center w-full h-full">
       <div className="flex flex-col items-center justify-center pt-16 w-full max-w-[500px] pad:max-w-[786px] dt:max-w-[1200px] max-pad:px-[16px]">
         <Post
-          noticeData={noticeData}
+          noticeData={{
+            ...data,
+            imageUrls: data.imageUrls || [],
+          }}
           commentCount={commentCount}
           replyCount={replyCount}
         />

--- a/app/(kahlua)/announcement/posting/page.tsx
+++ b/app/(kahlua)/announcement/posting/page.tsx
@@ -10,21 +10,23 @@ import TopButtons from '@/components/announcement/posting/TopButtons';
 
 const Page = () => {
   const searchParams = useSearchParams();
+  const router = useRouter();
+
   const title = searchParams.get('title');
   const content = searchParams.get('content');
   const imageUrls = searchParams.getAll('imageUrls');
-  const router = useRouter();
 
   const [currentTitle, setTitle] = useState('');
   const [currentContent, setContent] = useState('');
   const [currentImages, setCurrentImages] = useState<string[]>([]);
 
+  const isEditMode = title !== null;
   const isPostActive =
     currentTitle.trim() !== '' && currentContent.trim() !== '';
 
   useEffect(() => {
-    if (title) setTitle(title);
-    if (content) setContent(content);
+    setTitle(title || '');
+    setContent(content || '');
     if (imageUrls.length > 0) {
       setCurrentImages([...imageUrls]);
     }
@@ -50,10 +52,14 @@ const Page = () => {
       <section className="dt:w-[1200px] pad:w-[786px] ph:w-[328px] dt:pb-[578px] pad:pb-[559px] ph:pb-[171px]">
         <TopButtons isPostActive={isPostActive} onPublish={onPublish} />
         <TitleInput title={currentTitle} setTitle={setTitle} />
-        <ContentInput content={currentContent} setContent={setContent} />{' '}
-        {currentImages.length > 0 && (
-          <ImageUpload image={currentImages} setImage={setCurrentImages} />
-        )}
+        <ContentInput content={currentContent} setContent={setContent} />
+
+        <ImageUpload
+          image={currentImages}
+          setImage={setCurrentImages}
+          isEditMode={isEditMode}
+        />
+
         <CommunityRule />
       </section>
     </div>

--- a/app/(kahlua)/announcement/posting/page.tsx
+++ b/app/(kahlua)/announcement/posting/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useState, useEffect } from 'react';
-import { useSearchParams } from 'next/navigation';
+import { useSearchParams, useRouter } from 'next/navigation';
 import CommunityRule from '@/components/announcement/posting/CommunityRule';
 import ContentInput from '@/components/announcement/posting/ContentInput';
 import ImageUpload from '@/components/announcement/posting/ImageUpload';
@@ -13,6 +13,7 @@ const Page = () => {
   const title = searchParams.get('title');
   const content = searchParams.get('content');
   const imageUrls = searchParams.getAll('imageUrls');
+  const router = useRouter();
 
   const [currentTitle, setTitle] = useState('');
   const [currentContent, setContent] = useState('');
@@ -29,10 +30,25 @@ const Page = () => {
     }
   }, [title, content, imageUrls.length]);
 
+  const onPublish = () => {
+    const postData = {
+      title: currentTitle,
+      content: currentContent,
+      images: currentImages,
+    };
+
+    router.push('/announcement/post');
+
+    // 글 수정 api 추가
+    setTitle('');
+    setContent('');
+    setCurrentImages([]);
+  };
+
   return (
     <div className="relative flex flex-col items-center mt-[96px] mb-[-160px] font-pretendard">
       <section className="dt:w-[1200px] pad:w-[786px] ph:w-[328px] dt:pb-[578px] pad:pb-[559px] ph:pb-[171px]">
-        <TopButtons isPostActive={isPostActive} />
+        <TopButtons isPostActive={isPostActive} onPublish={onPublish} />
         <TitleInput title={currentTitle} setTitle={setTitle} />
         <ContentInput content={currentContent} setContent={setContent} />{' '}
         {currentImages.length > 0 && (

--- a/app/(kahlua)/announcement/posting/page.tsx
+++ b/app/(kahlua)/announcement/posting/page.tsx
@@ -1,24 +1,43 @@
 'use client';
+
+import React, { useState, useEffect } from 'react';
+import { useSearchParams } from 'next/navigation';
 import CommunityRule from '@/components/announcement/posting/CommunityRule';
 import ContentInput from '@/components/announcement/posting/ContentInput';
 import ImageUpload from '@/components/announcement/posting/ImageUpload';
 import TitleInput from '@/components/announcement/posting/TitleInput';
 import TopButtons from '@/components/announcement/posting/TopButtons';
-import React, { useState } from 'react';
 
 const Page = () => {
-  const [title, setTitle] = useState('');
-  const [content, setContent] = useState('');
+  const searchParams = useSearchParams();
+  const title = searchParams.get('title');
+  const content = searchParams.get('content');
+  const imageUrls = searchParams.getAll('imageUrls');
 
-  const isPostActive = title.trim() !== '' && content.trim() !== '';
+  const [currentTitle, setTitle] = useState('');
+  const [currentContent, setContent] = useState('');
+  const [currentImages, setCurrentImages] = useState<string[]>([]);
+
+  const isPostActive =
+    currentTitle.trim() !== '' && currentContent.trim() !== '';
+
+  useEffect(() => {
+    if (title) setTitle(title);
+    if (content) setContent(content);
+    if (imageUrls.length > 0) {
+      setCurrentImages([...imageUrls]);
+    }
+  }, [title, content, imageUrls.length]);
 
   return (
     <div className="relative flex flex-col items-center mt-[96px] mb-[-160px] font-pretendard">
       <section className="dt:w-[1200px] pad:w-[786px] ph:w-[328px] dt:pb-[578px] pad:pb-[559px] ph:pb-[171px]">
         <TopButtons isPostActive={isPostActive} />
-        <TitleInput title={title} setTitle={setTitle} />
-        <ContentInput content={content} setContent={setContent} />
-        <ImageUpload />
+        <TitleInput title={currentTitle} setTitle={setTitle} />
+        <ContentInput content={currentContent} setContent={setContent} />{' '}
+        {currentImages.length > 0 && (
+          <ImageUpload image={currentImages} setImage={setCurrentImages} />
+        )}
         <CommunityRule />
       </section>
     </div>

--- a/app/(kahlua)/announcement/posting/page.tsx
+++ b/app/(kahlua)/announcement/posting/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import { useSearchParams, useRouter } from 'next/navigation';
 import CommunityRule from '@/components/announcement/posting/CommunityRule';
 import ContentInput from '@/components/announcement/posting/ContentInput';
@@ -16,21 +16,15 @@ const Page = () => {
   const content = searchParams.get('content');
   const imageUrls = searchParams.getAll('imageUrls');
 
-  const [currentTitle, setTitle] = useState('');
-  const [currentContent, setContent] = useState('');
-  const [currentImages, setCurrentImages] = useState<string[]>([]);
+  const [currentTitle, setTitle] = useState(title || '');
+  const [currentContent, setContent] = useState(content || '');
+  const [currentImages, setCurrentImages] = useState(
+    imageUrls.length > 0 ? imageUrls : []
+  );
 
   const isEditMode = title !== null;
   const isPostActive =
     currentTitle.trim() !== '' && currentContent.trim() !== '';
-
-  useEffect(() => {
-    setTitle(title || '');
-    setContent(content || '');
-    if (imageUrls.length > 0) {
-      setCurrentImages([...imageUrls]);
-    }
-  }, [title, content, imageUrls.length]);
 
   const onPublish = () => {
     const postData = {

--- a/components/announcement/posting/ImageUpload.tsx
+++ b/components/announcement/posting/ImageUpload.tsx
@@ -3,9 +3,14 @@ import React, { useEffect, useRef, useState } from 'react';
 interface ImageUploadProps {
   image: string[];
   setImage: (value: string[]) => void;
+  isEditMode: boolean;
 }
 
-const ImageUpload: React.FC<ImageUploadProps> = ({ image, setImage }) => {
+const ImageUpload: React.FC<ImageUploadProps> = ({
+  image,
+  setImage,
+  isEditMode,
+}) => {
   const [images, setImages] = useState<string[]>(image);
   const [hasScrollbar, setHasScrollbar] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -46,10 +51,10 @@ const ImageUpload: React.FC<ImageUploadProps> = ({ image, setImage }) => {
 
   // 이미지가 추가되거나 삭제될 때마다 부모 컴포넌트에 전달
   useEffect(() => {
-    setImage(images);
-    console.log('현재 이미지 개수:', images.length); // 이미지 개수 로그 출력
-    console.log(images);
-  }, [images, setImage]);
+    if (isEditMode) {
+      setImages(image); // 수정 모드일 때 부모로부터 전달받은 이미지를 사용
+    }
+  }, [isEditMode, image]);
 
   // 이미지가 추가될 때마다 오른쪽으로 스크롤 이동
   useEffect(() => {

--- a/components/announcement/posting/ImageUpload.tsx
+++ b/components/announcement/posting/ImageUpload.tsx
@@ -1,7 +1,12 @@
 import React, { useEffect, useRef, useState } from 'react';
 
-const ImageUpload = () => {
-  const [images, setImages] = useState<string[]>([]);
+interface ImageUploadProps {
+  image: string[];
+  setImage: (value: string[]) => void;
+}
+
+const ImageUpload: React.FC<ImageUploadProps> = ({ image, setImage }) => {
+  const [images, setImages] = useState<string[]>(image);
   const [hasScrollbar, setHasScrollbar] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
 
@@ -12,14 +17,22 @@ const ImageUpload = () => {
       const newImages = Array.from(files).map(
         (file) => URL.createObjectURL(file) // 이미지 미리 볼 수 있게
       );
-      setImages((prevImages) => [...prevImages, ...newImages]);
+      setImages((prevImages) => {
+        const updatedImages = [...prevImages, ...newImages];
+        setImage(updatedImages); // Passing updated images to parent component
+        return updatedImages;
+      });
       setTimeout(checkScrollbar, 20);
     }
   };
 
   // 이미지 삭제
   const handleImageDelete = (index: number) => {
-    setImages((prevImages) => prevImages.filter((_, i) => i !== index));
+    setImages((prevImages) => {
+      const updatedImages = prevImages.filter((_, i) => i !== index); // Remove image at index
+      setImage(updatedImages); // Pass updated images to parent
+      return updatedImages;
+    });
   };
 
   // 스크롤바 유무 감지 함수
@@ -30,6 +43,13 @@ const ImageUpload = () => {
       setHasScrollbar(hasScroll);
     }
   };
+
+  // 이미지가 추가되거나 삭제될 때마다 부모 컴포넌트에 전달
+  useEffect(() => {
+    setImage(images);
+    console.log('현재 이미지 개수:', images.length); // 이미지 개수 로그 출력
+    console.log(images);
+  }, [images, setImage]);
 
   // 이미지가 추가될 때마다 오른쪽으로 스크롤 이동
   useEffect(() => {

--- a/components/announcement/posting/TopButtons.tsx
+++ b/components/announcement/posting/TopButtons.tsx
@@ -5,9 +5,10 @@ import CancelPopup from '@/components/announcement/posting/CancelPopup';
 
 interface TopButtonsProps {
   isPostActive: boolean;
+  onPublish: () => void;
 }
 
-const TopButtons: React.FC<TopButtonsProps> = ({ isPostActive }) => {
+const TopButtons: React.FC<TopButtonsProps> = ({ isPostActive, onPublish }) => {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const router = useRouter();
 
@@ -24,6 +25,12 @@ const TopButtons: React.FC<TopButtonsProps> = ({ isPostActive }) => {
     setIsModalOpen(false);
   };
 
+  const handlePublishClick = () => {
+    if (isPostActive) {
+      onPublish();
+    }
+  };
+
   return (
     <>
       <div className="flex justify-end mb-10">
@@ -34,6 +41,7 @@ const TopButtons: React.FC<TopButtonsProps> = ({ isPostActive }) => {
           취소
         </div>
         <div
+          onClick={handlePublishClick}
           className={`w-[100px] h-[46px] flex justify-center items-center rounded-[12px] ${
             isPostActive
               ? 'bg-primary-50 cursor-pointer'

--- a/components/notice/CommentInput.tsx
+++ b/components/notice/CommentInput.tsx
@@ -31,7 +31,11 @@ const CommentInput: React.FC<CommentInputProps> = ({
         className="border rounded-lg border-black min-w-[60px] min-h-[60px] cursor-pointer flex items-center justify-center"
         onClick={onAddComment}
       >
-        <Send width={20} height={20} style={{ transform: 'rotate(-40deg)' }} />
+        <Send
+          width={20}
+          height={20}
+          style={{ margin: '0px 0px 4px 2px', transform: 'rotate(-40deg)' }}
+        />
       </button>
     </div>
   );

--- a/components/notice/Post.tsx
+++ b/components/notice/Post.tsx
@@ -7,9 +7,10 @@ import ContentSection from '@/components/notice/post/ContentSection';
 
 interface NoticeData {
   title?: string;
-  text?: string;
-  author?: string;
+  content?: string;
+  user?: string;
   date?: string;
+  imageUrls?: string[] | string | null;
 }
 interface PostProps {
   noticeData: NoticeData;
@@ -22,7 +23,6 @@ const Post: React.FC<PostProps> = ({
   commentCount,
   replyCount,
 }) => {
-  const [chatCount, setChatCount] = useState(0);
   const [showDeletePopup, setShowDeletePopup] = useState(false);
 
   const handleDeleteClick = () => {
@@ -38,19 +38,30 @@ const Post: React.FC<PostProps> = ({
     // 글 삭제 취소
     setShowDeletePopup(false);
   };
-
+  const imageUrls = noticeData?.imageUrls
+    ? Array.isArray(noticeData?.imageUrls)
+      ? noticeData?.imageUrls // 배열이면 그대로
+      : typeof noticeData?.imageUrls === 'string'
+        ? noticeData?.imageUrls.split(',').map((img) => img.trim()) // 문자열일 경우 , 기준으로 나누어 배열로 변환
+        : [] // null이나 undefined일 경우 빈 배열
+    : [];
   return (
     <div className="w-full">
       <div className="flex flex-col w-full">
         <div className="flex flex-col gap-16">
           <TitleSection
             title={noticeData?.title || 'No Title'}
-            author={noticeData?.author || 'Unknown'}
+            user={noticeData?.user || 'Unknown'}
             date={noticeData?.date || 'Unknown'}
+            content={noticeData?.content || 'No Content'}
+            imageUrls={imageUrls}
             onDeleteClick={handleDeleteClick}
           />
           <div className="w-full border-b border-gray-15" />
-          <ContentSection text={noticeData?.text || ''} />
+          <ContentSection
+            text={noticeData?.content || ''}
+            imageUrls={imageUrls}
+          />
         </div>
         <InfoSection commentCount={commentCount} replyCount={replyCount} />
       </div>

--- a/components/notice/post/ContentSection.tsx
+++ b/components/notice/post/ContentSection.tsx
@@ -3,14 +3,28 @@ import React from 'react';
 
 interface ContentSectionProps {
   text: string;
+  imageUrls: string[] | null;
 }
 
-const ContentSection: React.FC<ContentSectionProps> = ({ text }) => {
+const ContentSection: React.FC<ContentSectionProps> = ({ text, imageUrls }) => {
   return (
     <>
       <div className="font-pretendard text-xl font-medium whitespace-pre-wrap">
         {text}
       </div>
+
+      {imageUrls && imageUrls.length > 0 && (
+        <div className="mt-4 flex overflow-x-auto gap-6">
+          {imageUrls.map((imageUrl, index) => (
+            <img
+              key={index}
+              src={imageUrl}
+              alt={`content-image-${index}`}
+              className="w-[300px] h-[400px] object-cover rounded-xl"
+            />
+          ))}
+        </div>
+      )}
       <div className="w-full border-b border-gray-15" />
     </>
   );

--- a/components/notice/post/TitleSection.tsx
+++ b/components/notice/post/TitleSection.tsx
@@ -1,18 +1,23 @@
 import React from 'react';
 import Image from 'next/image';
+import Link from 'next/link';
 import defaultImg from '@/public/image/notice/defaultProfile.svg';
 
 interface TitleSectionProps {
   title?: string;
-  author?: string;
+  user?: string;
   date?: string;
+  content?: string;
+  imageUrls?: string[] | string | null;
   onDeleteClick: () => void;
 }
 
 const TitleSection: React.FC<TitleSectionProps> = ({
   title = 'No Title',
-  author = 'Unknown',
+  user = 'Unknown',
   date = 'Unknown',
+  content = 'No Content',
+  imageUrls = '',
   onDeleteClick,
 }) => {
   return (
@@ -31,7 +36,7 @@ const TitleSection: React.FC<TitleSectionProps> = ({
         <span className="w-full flex flex-row mt-[16px] items-center justify-between">
           <div className="flex flex-row gap-2">
             <span className="font-pretendard text-base font-medium flex">
-              {author}
+              {user}
             </span>
             <div className="border-l border-black h-[24px]" />
             <span className="font-pretendard text-base font-medium flex">
@@ -39,9 +44,18 @@ const TitleSection: React.FC<TitleSectionProps> = ({
             </span>
           </div>
           <div className="flex gap-4">
-            <span className="font-pretendard text-base font-normal cursor-pointer">
-              수정
-            </span>
+            <Link
+              href={{
+                pathname: '/announcement/posting',
+                query: { title, content, imageUrls },
+              }}
+              passHref
+            >
+              <span className="font-pretendard text-base font-normal cursor-pointer">
+                수정
+              </span>
+            </Link>
+
             <span
               className="font-pretendard text-base text-danger-50 font-normal cursor-pointer"
               onClick={onDeleteClick}


### PR DESCRIPTION
## 📝작업 내용
1. /announcement/posting에서 글 수정 버튼 눌렀을 경우 /announcement/posting으로 이동 구현
2. /announcement/posting에는 방금 전 글 내용을 초기 데이터로 갖도록 구조 수정
3. 글 조회 부분에서 사진 구조 추가

<img width="1182" alt="스크린샷 2024-11-17 오후 6 18 45" src="https://github.com/user-attachments/assets/9320ce14-05a9-4f47-b2d1-0a0abd7b033d">

<img width="1197" alt="스크린샷 2024-11-17 오후 6 19 36" src="https://github.com/user-attachments/assets/c816dfed-2cf4-428a-85f8-4671ac83a584">


## 🔎코드 설명 및 참고 사항
> 현재는 내용을 파라미터로 넘겨줘서 임시 데이터를 가져오고 있는데, 
api 연결 시에는 글 아이디 기준으로 가져오도록 수정되어야 할 것 같숩니다,,

## 💬리뷰 요구사항
> 

## ⚠️로컬 실행 시 유의사항
>
