### PR TITLE
Feat: Performance 페이지 제작

### DIFF
--- a/components/performance/MainContainer.tsx
+++ b/components/performance/MainContainer.tsx
@@ -1,19 +1,18 @@
 'use client';
-import YearSelector from '@/components/performance/YearSelector';
-import Playlists from '@/components/performance/Playlists';
+import TicektList from './TicketList';
 
 const MainContainer = () => {
   return (
     <>
-      <div className="pad:w-[786px] dt:w-[1200px] min-h-[320px] flex flex-col bg-gray-90 items-center ph:rounded-none w-full pad:rounded-3xl mt-[16px] mb-[32px]">
-        <h1 className="font-mustica text-4xl pad:text-[64px] font-semibold leading-[83.2px] text-gray-0 mt-[64px]">
+      <div className="pad:w-[786px] dt:w-[1200px] h-[260px] pad:h-[320px] flex flex-col gap-7 pad:gap-12 bg-gray-90 items-center ph:rounded-none w-full pad:rounded-3xl mt-[16px] mb-[32px]">
+        <h1 className="font-mustica text-4xl pad:text-[64px] font-semibold leading-[83.2px] text-gray-0 pad:mt-[76px] mt-[68px]">
           PERFORMANCE
         </h1>
-        {/* 연도 선택 관련 요소 */}
-        <YearSelector />
+        <p className="font-pretendard text-xl pad:text-2xl font-semibold text-gray-0">
+          깔루의 공연을 즐겨보세요
+        </p>
       </div>
-      {/* 유튜브 재생목록 섹션 */}
-      <Playlists />
+      <TicektList />
     </>
   );
 };

--- a/components/performance/MainContainer.tsx
+++ b/components/performance/MainContainer.tsx
@@ -9,7 +9,7 @@ const MainContainer = () => {
           PERFORMANCE
         </h1>
         <p className="font-pretendard text-xl pad:text-2xl font-semibold text-gray-0">
-          깔루의 공연을 즐겨보세요
+          깔루아의 공연을 즐겨보세요
         </p>
       </div>
       <TicektList />

--- a/components/performance/TicketList.tsx
+++ b/components/performance/TicketList.tsx
@@ -10,6 +10,8 @@ interface Performance {
   content: string;
   posterUrl: string;
   status: 'OPEN' | 'CLOSED';
+  youtube_url: string;
+  link: string;
 }
 
 const TicektList = () => {

--- a/components/performance/TicketList.tsx
+++ b/components/performance/TicketList.tsx
@@ -5,44 +5,44 @@ import WidePlaylistItem from '../ticket/WidePlaylistItem';
 
 const TicektList = () => {
   return (
-    <>
-      <div className="pad:w-[786px] dt:w-[1200px] h-full grid grid-cols-1 pad:grid-cols-4 pad:gap-x-4 dt:gap-x-9 gap-y-12">
-        {/* 태블릿, 데스크탑 */}
-        {RecommendData.map((show, index) => (
-          <div
-            key={index}
-            className="max-[833px]:hidden relative block w-[184px] dt:w-[273px]"
-          >
-            {show.isLive && (
-              <div className="flex items-center justify-center rounded-[20px] z-30 text-center absolute top-[15px] left-[13px] w-[42px] h-[23px] bg-primary-40 text-gray-0 text-xs font-medium rounded-5">
-                공연중
-              </div>
-            )}
-            <Link href={show.link} className="block">
-              <div className="relative w-full h-[257px] dt:h-[380px] rounded-lg overflow-hidden cursor-pointer">
-                <Image
-                  src={show.image}
-                  alt={show.title}
-                  layout="fill"
-                  objectFit="cover"
-                />
-              </div>
-            </Link>
-            <p className="mt-3 text-left font-pretendard text-base font-semibold text-gray-90">
-              {show.title}
-            </p>
-            <p className="text-left text-sm font-pretendard font-normal text-gray-40">
-              {show.description}
-            </p>
-          </div>
-        ))}
+    <div className="pad:w-[786px] dt:w-[1200px] h-full grid grid-cols-1 pad:grid-cols-4 pad:gap-x-4 dt:gap-x-9 gap-y-12">
+      {/* 태블릿 & 데스크탑 */}
+      {RecommendData.map((show, index) => (
+        <div
+          key={index}
+          className="max-[833px]:hidden relative block w-[184px] dt:w-[273px]"
+        >
+          {show.isLive && (
+            <div className="flex items-center justify-center rounded-[20px] z-30 text-center absolute top-[15px] left-[13px] w-[42px] h-[23px] bg-primary-40 text-gray-0 text-xs font-medium">
+              공연중
+            </div>
+          )}
+          <Link href={show.link} className="block">
+            <div className="relative w-full h-[257px] dt:h-[380px] rounded-lg overflow-hidden cursor-pointer">
+              <Image
+                src={show.image}
+                alt={show.title}
+                layout="fill"
+                objectFit="cover"
+              />
+            </div>
+          </Link>
+          <p className="mt-3 text-left font-pretendard text-base font-semibold text-gray-90">
+            {show.title}
+          </p>
+          <p className="text-left text-sm font-pretendard font-normal text-gray-40">
+            {show.description}
+          </p>
+        </div>
+      ))}
 
-        {/* 모바일 */}
-        {RecommendData.map((show, index) => (
-          <WidePlaylistItem key={index} show={show} />
-        ))}
-      </div>
-    </>
+      {/* 모바일 */}
+      {RecommendData.map((show, index) => (
+        <div key={index} className="hidden max-[833px]:block w-full">
+          <WidePlaylistItem show={show} />
+        </div>
+      ))}
+    </div>
   );
 };
 

--- a/components/performance/TicketList.tsx
+++ b/components/performance/TicketList.tsx
@@ -1,0 +1,49 @@
+import Image from 'next/image';
+import Link from 'next/link';
+import { RecommendData } from '../data/RecommendData';
+import WidePlaylistItem from '../ticket/WidePlaylistItem';
+
+const TicektList = () => {
+  return (
+    <>
+      <div className="pad:w-[786px] dt:w-[1200px] h-full grid grid-cols-1 pad:grid-cols-4 pad:gap-x-4 dt:gap-x-9 gap-y-12">
+        {/* 태블릿, 데스크탑 */}
+        {RecommendData.map((show, index) => (
+          <div
+            key={index}
+            className="max-[833px]:hidden relative block w-[184px] dt:w-[273px]"
+          >
+            {show.isLive && (
+              <div className="flex items-center justify-center rounded-[20px] z-30 text-center absolute top-[15px] left-[13px] w-[42px] h-[23px] bg-primary-40 text-gray-0 text-xs font-medium rounded-5">
+                공연중
+              </div>
+            )}
+            <Link href={show.link} className="block">
+              <div className="relative w-full h-[257px] dt:h-[380px] rounded-lg overflow-hidden cursor-pointer">
+                <Image
+                  src={show.image}
+                  alt={show.title}
+                  layout="fill"
+                  objectFit="cover"
+                />
+              </div>
+            </Link>
+            <p className="mt-3 text-left font-pretendard text-base font-semibold text-gray-90">
+              {show.title}
+            </p>
+            <p className="text-left text-sm font-pretendard font-normal text-gray-40">
+              {show.description}
+            </p>
+          </div>
+        ))}
+
+        {/* 모바일 */}
+        {RecommendData.map((show, index) => (
+          <WidePlaylistItem key={index} show={show} />
+        ))}
+      </div>
+    </>
+  );
+};
+
+export default TicektList;

--- a/components/performance/TicketList.tsx
+++ b/components/performance/TicketList.tsx
@@ -1,47 +1,120 @@
+import { authInstance } from '@/api/auth/axios';
 import Image from 'next/image';
 import Link from 'next/link';
-import { RecommendData } from '../data/RecommendData';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import WidePlaylistItem from '../ticket/WidePlaylistItem';
 
+interface Performance {
+  ticketInfoId: number;
+  title: string;
+  content: string;
+  posterUrl: string;
+  status: 'OPEN' | 'CLOSED';
+}
+
 const TicektList = () => {
+  const [data, setData] = useState<Performance[]>([]);
+  const [nextCursor, setNextCursor] = useState<number | null>(null);
+  const [hasNext, setHasNext] = useState<boolean>(true);
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+
+  const observerRef = useRef<HTMLDivElement | null>(null);
+
+  const fetchPerformanceData = async () => {
+    if (!hasNext || isLoading) return;
+
+    setIsLoading(true);
+
+    try {
+      const response = await authInstance.get('/performances', {
+        params: {
+          cursor: nextCursor !== null ? nextCursor : undefined,
+          limit: 8,
+        },
+      });
+
+      if (response.data.isSuccess) {
+        setData((prev) => [...prev, ...response.data.result.performances]);
+        setNextCursor(response.data.result.nextcursor);
+        setHasNext(response.data.result.hasNext);
+      }
+    } catch (error) {
+      console.error('공연 가져오기 실패: ', error);
+    }
+
+    setIsLoading(false);
+  };
+
+  const observerCallback: IntersectionObserverCallback = useCallback(
+    (entries) => {
+      if (entries[0].isIntersecting && !isLoading) {
+        fetchPerformanceData();
+      }
+    },
+    [isLoading]
+  );
+
+  useEffect(() => {
+    if (!observerRef.current) return;
+
+    const observer = new IntersectionObserver(observerCallback, {
+      root: null,
+      threshold: 0.5,
+    });
+
+    observer.observe(observerRef.current);
+    return () => observer.disconnect();
+  }, [observerCallback]);
+
+  useEffect(() => {
+    fetchPerformanceData();
+  }, []);
+
   return (
     <div className="pad:w-[786px] dt:w-[1200px] h-full grid grid-cols-1 pad:grid-cols-4 pad:gap-x-4 dt:gap-x-9 gap-y-12">
       {/* 태블릿 & 데스크탑 */}
-      {RecommendData.map((show, index) => (
+      {data.map((performance) => (
         <div
-          key={index}
+          key={performance.ticketInfoId}
           className="max-[833px]:hidden relative block w-[184px] dt:w-[273px]"
         >
-          {show.isLive && (
+          {performance.status === 'OPEN' && (
             <div className="flex items-center justify-center rounded-[20px] z-30 text-center absolute top-[15px] left-[13px] w-[42px] h-[23px] bg-primary-40 text-gray-0 text-xs font-medium">
               공연중
             </div>
           )}
-          <Link href={show.link} className="block">
+          <Link href={`/ticket/${performance.ticketInfoId}`} className="block">
             <div className="relative w-full h-[257px] dt:h-[380px] rounded-lg overflow-hidden cursor-pointer">
               <Image
-                src={show.image}
-                alt={show.title}
+                src={performance.posterUrl}
+                alt={performance.title}
                 layout="fill"
                 objectFit="cover"
               />
             </div>
           </Link>
           <p className="mt-3 text-left font-pretendard text-base font-semibold text-gray-90">
-            {show.title}
+            {performance.title}
           </p>
           <p className="text-left text-sm font-pretendard font-normal text-gray-40">
-            {show.description}
+            {performance.content}
           </p>
         </div>
       ))}
 
       {/* 모바일 */}
-      {RecommendData.map((show, index) => (
-        <div key={index} className="hidden max-[833px]:block w-full">
-          <WidePlaylistItem show={show} />
+      {data.map((performance) => (
+        <div
+          key={performance.ticketInfoId}
+          className="hidden max-[833px]:block w-full"
+        >
+          <WidePlaylistItem show={performance} />
         </div>
       ))}
+
+      <div ref={observerRef} className="w-full h-10" />
+
+      {isLoading && <p className="text-center text-gray-500">불러오는 중...</p>}
     </div>
   );
 };

--- a/components/performance/TicketList.tsx
+++ b/components/performance/TicketList.tsx
@@ -108,13 +108,14 @@ const TicektList = () => {
           key={performance.ticketInfoId}
           className="hidden max-[833px]:block w-full"
         >
-          <WidePlaylistItem show={performance} />
+          <WidePlaylistItem
+            show={performance}
+            id={String(performance.ticketInfoId)}
+          />
         </div>
       ))}
 
       <div ref={observerRef} className="w-full h-10" />
-
-      {isLoading && <p className="text-center text-gray-500">불러오는 중...</p>}
     </div>
   );
 };

--- a/components/ticket/WidePlaylistItem.tsx
+++ b/components/ticket/WidePlaylistItem.tsx
@@ -1,43 +1,40 @@
 import Image from 'next/image';
 import Link from 'next/link';
 
-interface Show {
+interface Performance {
+  ticketInfoId: number;
   title: string;
-  image: string;
-  link: string;
-  description: string;
-  isLive?: boolean;
+  content: string;
+  posterUrl: string;
+  status: 'OPEN' | 'CLOSED';
 }
 
-const WidePlaylistItem = ({ show }: { show: Show }) => {
+const WidePlaylistItem = ({ show }: { show: Performance }) => {
   return (
-    <div className="flex flex-row overflow-hidden cursor-pointer gap-[14px] w-[344px] h-[184px] rounded-[10px] border-[0.5px] border-black">
-      <div className="relative w-[128px] h-[184px] overflow-hidden rounded-[10px]">
-        {show.isLive && (
-          <div className="flex items-center justify-center rounded-[20px] z-30 text-center absolute top-[5px] left-[5px] w-[42px] h-[23px] bg-primary-40 text-gray-0 text-xs font-medium rounded-5">
+    <div className="flex overflow-hidden cursor-pointer gap-[14px] w-[344px] h-[184px] rounded-[10px] border border-black">
+      {/* 이미지 영역 */}
+      <div className="relative w-[128px] h-full overflow-hidden rounded-[10px]">
+        {show.status === 'OPEN' && (
+          <div className="z-30 flex items-center justify-center absolute top-[5px] left-[5px] w-[42px] h-[23px] bg-primary-40 text-gray-0 text-xs font-medium rounded-[5px]">
             공연중
           </div>
         )}
-
-        {/* 이미지 */}
-        <Link href={show.link}>
+        <Link href={`/ticket/${show.ticketInfoId}`}>
           <Image
-            src={show.image}
+            src={show.posterUrl}
             alt={show.title}
             layout="fill"
-            objectFit="cover"
-            className="rounded-[10px]"
+            className="object-cover rounded-[10px]"
           />
         </Link>
       </div>
 
-      {/* 텍스트 정보 */}
-      <div className="flex flex-col w-[200px] justify-center gap-[5px]">
+      <div className="flex flex-col justify-center gap-[5px] w-[200px]">
         <p className="text-left font-pretendard text-base font-semibold text-gray-90">
           {show.title}
         </p>
         <p className="text-left text-sm font-pretendard font-normal text-gray-40">
-          {show.description}
+          {show.content}
         </p>
       </div>
     </div>

--- a/components/ticket/WidePlaylistItem.tsx
+++ b/components/ticket/WidePlaylistItem.tsx
@@ -1,8 +1,7 @@
 import Image from 'next/image';
 import Link from 'next/link';
 
-interface Performance {
-  ticketInfoId: number;
+interface Show {
   title: string;
   posterUrl: string;
   link: string;


### PR DESCRIPTION
## 📝작업 내용
>  변경된 Performance 페이지 제작했습니다.
변경 이전: 공연 영상 리스트 페이지
변경 이후: 공연 티켓 리스트 페이지, 페이지 무한 스크롤 적용

[ 데스크탑 ]
![스크린샷 2025-02-20 오후 11 05 20](https://github.com/user-attachments/assets/628a4ba3-bb1d-4d68-a16f-9325761857a6)

[ 태블릿 ]
![스크린샷 2025-02-20 오후 11 05 33](https://github.com/user-attachments/assets/c89f684a-26b9-416e-bccd-15858bb6aa74)

[ 모바일 ]
![스크린샷 2025-02-20 오후 11 05 48](https://github.com/user-attachments/assets/075de18a-043e-4f5b-9a4d-f92a76b890f2)


## 🔎코드 설명 및 참고 사항
>  모바일 / 태블릿, 데스크탑으로 구분하여 공연 카드 컴포넌트 적용했습니다.
TicketList.tsx에 한번에 코드 작성했습니다.
WindePlaylistItem.tsx 컴포넌트 실제 api 명세에 맞게 수정했습니다.

## 참고사항
> ~현재 api 요청에 limit: 8을 보내는데, 실제로 더 많은 데이터가 있는 경우 테스트가 필요합니다.~
