### PR TITLE
#175 Feat: fix head component in applying google tag

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,6 +6,7 @@ import Header from '@/components/Header';
 import { usePathname } from 'next/navigation';
 import { useEffect, useState } from 'react';
 import './globals.css';
+import Head from 'next/head';
 
 import * as gtag from '../libs/gtag';
 
@@ -66,7 +67,7 @@ export default function RootLayout({
     <>
       <RecoilRoot>
         <html lang="en">
-          <head>
+          <Head>
             {/*<!-- Google tag (gtag.js) -->*/}
             <script
               async
@@ -90,7 +91,7 @@ export default function RootLayout({
             <meta property="og:type" content="website" />
             <meta property="og:image" content="/image/Thumbnail.png?v=1" />
             <meta property="og:url" content="https://kahluaband.com" />
-          </head>
+          </Head>
           <body className={roboto.className}>
             <div className="font-pretendard w-full h-auto mb-40">
               <Header />


### PR DESCRIPTION
## #️⃣연관된 이슈
> close #175 

## 📝작업 내용
> 구글 애널리틱스 내용 태그 변경



## 🔎코드 설명 및 참고 사항
> <head></head> 태그가 적용이 안되고 있어서 
> `import Head from 'next/head';`로 변경

## 💬리뷰 요구사항
> 구글 애널리틱스 적용 방법이 올바른지 확인부탁드립니다!

## ⚠️로컬 실행 시 유의사항
> x
