### PR TITLE
Feat: 공연 정보 수정 페이지 추가, 동방 예약 에러 해결

### DIFF
--- a/app/(kahlua)/admin/page.tsx
+++ b/app/(kahlua)/admin/page.tsx
@@ -4,7 +4,7 @@ import AdminPageButton from '@/components/admin/adminPageButton';
 let AdminUrl = [
   { name: '공연 예매 현황', url: '/admin/ticketing' },
   { name: '지원 현황', url: '/admin/applicant' },
-  { name: '공연 정보 관리', url: '/admin/performanceInfo' },
+  { name: '공연 정보 생성', url: '/admin/performanceInfo' },
   { name: '지원 정보 관리', url: '/admin/recruitingInfo' },
 ];
 

--- a/app/(kahlua)/admin/performance/[id]/page.tsx
+++ b/app/(kahlua)/admin/performance/[id]/page.tsx
@@ -1,0 +1,233 @@
+'use client';
+
+import { authInstance } from '@/api/auth/axios';
+import CancelModal from '@/components/admin/CancelModal';
+import EditModal from '@/components/admin/EditModal';
+import InfoList from '@/components/templates/admin/Info';
+import AdminButton from '@/components/ui/admin/Button';
+import ImageBox from '@/components/ui/admin/ImageBox';
+import TicketInfoList from '@/components/ui/admin/TicketInfo';
+import Banner from '@/components/ui/Banner';
+import WestIcon from '@mui/icons-material/West';
+import { useParams, useRouter } from 'next/navigation';
+import { useCallback, useEffect, useState } from 'react';
+import {
+  defaultData,
+  defaultFreshmanTicketData,
+  defaultGeneralTicketData,
+  defaultImage,
+  freshmanTiketInfoList,
+  generalTiketInfoList,
+  performanceImage,
+  performanceInfoList,
+} from '../../performanceInfo/performanceData';
+
+const EditPerformancePage = () => {
+  const params = useParams();
+  const router = useRouter();
+
+  const [data, setData] = useState<{ [key: string]: any }>(defaultData);
+  const [freshmanTicketData, setFreshmanTicketData] = useState<{
+    [key: string]: number;
+  }>(defaultFreshmanTicketData);
+  const [generalTicketData, setGeneralTicketData] = useState<{
+    [key: string]: number;
+  }>(defaultGeneralTicketData);
+  const [image, setImage] = useState<{ [key: string]: string }>(defaultImage);
+  const [isEditModalOpen, setIsEditModalOpen] = useState<boolean>(false);
+  const [isCancelModalOpen, setIsCancelModalOpen] = useState<boolean>(false);
+  const [isLoading, setIsLoading] = useState(true);
+
+  // 공연 정보 가져오기
+  useEffect(() => {
+    const fetchPerformance = async () => {
+      try {
+        const response = await authInstance.get(`/performances/${params.id}`);
+        if (response.data.isSuccess) {
+          const performanceData = response.data.result.performanceResponse;
+
+          setData({
+            title: performanceData.title,
+            content: performanceData.content,
+            venue: performanceData.venue,
+            address: performanceData.address,
+            dateTime: performanceData.date_time,
+            bookingStartDate: performanceData.booking_start_date,
+            bookingEndDate: performanceData.booking_end_date,
+            youtubeUrl: performanceData.youtube_url || '',
+          });
+
+          setImage({
+            posterImageUrl: performanceData.poster_image_url,
+          });
+
+          setFreshmanTicketData({
+            freshmanPrice: Number(performanceData.freshman_price),
+            freshmanMaxPurchase: performanceData.freshman_max_purchase,
+          });
+
+          setGeneralTicketData({
+            generalPrice: Number(performanceData.general_price),
+            generalMaxPurchase: performanceData.general_max_purchase,
+          });
+        }
+      } catch (error) {
+        console.error('공연 정보 불러오기 실패:', error);
+        alert('공연 정보를 불러오는데 실패했습니다.');
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    if (params.id) {
+      fetchPerformance();
+    }
+  }, [params.id]);
+
+  const onChangeData = useCallback((newValue: any, label: string) => {
+    setData((prevData) => ({
+      ...prevData,
+      [label]: newValue,
+    }));
+  }, []);
+
+  const onChangeImage = useCallback((newValue: string, label: string) => {
+    setImage((prevData) => ({
+      ...prevData,
+      [label]: newValue,
+    }));
+  }, []);
+
+  const onChangeFreshmanTicketData = useCallback(
+    (newValue: number, label: string) => {
+      setFreshmanTicketData((prevData) => ({
+        ...prevData,
+        [label]: newValue,
+      }));
+    },
+    []
+  );
+
+  const onChangeGeneralTicketData = useCallback(
+    (newValue: number, label: string) => {
+      setGeneralTicketData((prevData) => ({
+        ...prevData,
+        [label]: newValue,
+      }));
+    },
+    []
+  );
+
+  // 공연 정보 수정
+  const onSaveEdit = useCallback(async () => {
+    try {
+      const performanceData = {
+        posterImageUrl: image.posterImageUrl,
+        youtubeUrl: data.youtubeUrl,
+        title: data.title,
+        content: data.content,
+        venue: data.venue,
+        address: data.address,
+        dateTime: data.dateTime,
+        freshmanPrice: String(freshmanTicketData.freshmanPrice),
+        freshmanMaxPurchase: freshmanTicketData.freshmanMaxPurchase,
+        generalPrice: String(generalTicketData.generalPrice),
+        generalMaxPurchase: generalTicketData.generalMaxPurchase,
+        bookingStartDate: data.bookingStartDate,
+        bookingEndDate: data.bookingEndDate,
+      };
+
+      const response = await authInstance.put(
+        `/admin/tickets/${params.id}`,
+        performanceData
+      );
+
+      if (response.status === 200) {
+        alert('공연 정보가 성공적으로 수정되었습니다.');
+        setIsEditModalOpen(false);
+        router.push(`/ticket/${params.id}`);
+      }
+    } catch (error: any) {
+      console.error('공연 정보 수정 실패:', error);
+      alert('공연 정보 수정에 실패했습니다.');
+    }
+  }, [data, image, freshmanTicketData, generalTicketData, params.id, router]);
+
+  const onCancelEdit = useCallback(() => {
+    router.push(`/ticket/${params.id}`);
+  }, [router, params.id]);
+
+  if (isLoading) {
+    return (
+      <div className="flex justify-center items-center w-full h-screen">
+        <p className="text-gray-500 text-lg font-medium">로딩중...</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="font-pretendard mx-auto w-full pad:w-[786px] dt:w-[1200px] h-auto flex flex-col gap-[40px]">
+      <Banner>공연 정보 수정</Banner>
+
+      <div className="flex flex-col pad:flex-row w-full max-pad:px-[16px] gap-[40px] justify-center items-center pad:items-start">
+        <ImageBox
+          data={image}
+          field={performanceImage}
+          onChange={onChangeImage}
+        />
+        <div className="flex flex-col w-full gap-[16px]">
+          <InfoList
+            data={data}
+            fieldList={performanceInfoList}
+            onChange={onChangeData}
+          />
+          <TicketInfoList
+            data={freshmanTicketData}
+            fieldList={freshmanTiketInfoList}
+            onChange={onChangeFreshmanTicketData}
+          >
+            신입생
+          </TicketInfoList>
+          <TicketInfoList
+            data={generalTicketData}
+            fieldList={generalTiketInfoList}
+            onChange={onChangeGeneralTicketData}
+          >
+            일반
+          </TicketInfoList>
+        </div>
+      </div>
+
+      <div className="flex flex-row gap-[24px] w-full max-pad:px-[16px] justify-end">
+        <AdminButton onClick={onCancelEdit}>취소하기</AdminButton>
+        <AdminButton
+          onClick={() => setIsEditModalOpen(true)}
+          className="bg-primary-50"
+        >
+          수정하기
+        </AdminButton>
+        <EditModal
+          isOpen={isEditModalOpen}
+          setIsOpen={setIsEditModalOpen}
+          handleSubmit={onSaveEdit}
+        />
+      </div>
+
+      <div className="flex w-auto h-auto max-pad:mx-[16px]">
+        <div
+          className="flex flex-row gap-[8px] items-center cursor-pointer"
+          onClick={() => setIsCancelModalOpen(true)}
+        >
+          <WestIcon />
+          <span className="text-[16px] font-medium">Admin 홈으로</span>
+        </div>
+      </div>
+      <CancelModal
+        isOpen={isCancelModalOpen}
+        setIsOpen={setIsCancelModalOpen}
+      />
+    </div>
+  );
+};
+
+export default EditPerformancePage;

--- a/components/admin/EditModal.tsx
+++ b/components/admin/EditModal.tsx
@@ -15,8 +15,8 @@ const EditModal: React.FC<ModalProps> = ({
     <ButtonModal
       isOpen={isOpen}
       onClose={() => setIsOpen(false)}
-      mainContent={<p>공연 정보를 생성하시겠습니까?</p>}
-      buttonContent={<p>생성하기</p>}
+      mainContent={<p>공연 정보를 수정하시겠습니까?</p>}
+      buttonContent={<p>수정하기</p>}
       handleSubmit={() => handleSubmit()}
     />
   );

--- a/components/reservation/CalendarUI.css
+++ b/components/reservation/CalendarUI.css
@@ -21,7 +21,7 @@
 .react-calendar__tile--active,
 .react-calendar__tile--active.react-calendar__tile--now {
   background-color: theme('colors.primary.50') !important;
-  color: theme('colors.gray.0');
+  color: theme('colors.gray.0') !important;
 }
 
 .react-calendar__tile:enabled:focus {
@@ -62,6 +62,13 @@
   background-color: transparent !important;
 }
 
+.react-calendar__month-view__days__day {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  aspect-ratio: 1;
+}
+
 .react-calendar__month-view__days__day--weekend {
   color: black;
 }
@@ -69,7 +76,7 @@
 .react-calendar__month-view__weekdays {
   font-size: 24px;
   font-weight: 400;
-  color: theme(colors.gray.60);
+  color: theme('colors.gray.60');
 }
 
 .react-calendar__month-view__weekdays__weekday {
@@ -88,7 +95,7 @@
 
 @media (max-width: 834px) {
   .react-calendar__tile {
-    height: 60px;
+    height: auto;
     font-size: 14px;
   }
   .react-calendar__month-view__weekdays__weekday {
@@ -96,5 +103,8 @@
   }
   .react-calendar__navigation__label {
     font-size: 20px;
+  }
+  .react-calendar button {
+    border-radius: 100%;
   }
 }

--- a/components/reservation/TimeTable.tsx
+++ b/components/reservation/TimeTable.tsx
@@ -58,18 +58,6 @@ const TimeTable = ({
     return user?.email === email;
   };
 
-  // 예약 불가능한 시간 확인
-  const isTimeSlotReserved = (startTime: string, endTime: string) => {
-    const formattedStartTime = `${startTime}:00`;
-    const formattedEndTime = `${endTime}:00`;
-
-    return reservationsForDate.some(
-      (reservation) =>
-        reservation.startTime <= formattedStartTime &&
-        reservation.endTime >= formattedEndTime
-    );
-  };
-
   // 예약자 확인
   const getReservedByName = (startTime: string, endTime: string) => {
     const formattedStartTime = `${startTime}:00`;
@@ -132,8 +120,6 @@ const TimeTable = ({
         ? startTimeStr
         : reservation.startTime;
       const actualEndTime = isEndTimeEarlier ? reservation.endTime : endTimeStr;
-
-      console.log('선택된 시간: ', actualStartTime, actualEndTime);
 
       const newSelectedTimes = generateTimeRange(
         actualStartTime,

--- a/components/reservation/TimeTable.tsx
+++ b/components/reservation/TimeTable.tsx
@@ -119,10 +119,26 @@ const TimeTable = ({
     // 시작 시간이 설정된 상태에서 두 번째 클릭: 종료 시간으로 설정
     else {
       onChange('endTime', endTimeStr);
+      const [startHour, startMinute] = reservation.startTime
+        .split(':')
+        .map(Number);
+      const [endHour, endMinute] = endTimeStr.split(':').map(Number);
+
+      // 시작 시간과 종료 시간을 비교하여 순서를 결정
+      const isEndTimeEarlier =
+        endHour < startHour ||
+        (endHour === startHour && endMinute < startMinute);
+      const actualStartTime = isEndTimeEarlier
+        ? startTimeStr
+        : reservation.startTime;
+      const actualEndTime = isEndTimeEarlier ? reservation.endTime : endTimeStr;
+
+      console.log('선택된 시간: ', actualStartTime, actualEndTime);
+
       const newSelectedTimes = generateTimeRange(
-        reservation.startTime,
-        endTimeStr
-      ); // 사이 시간 모두 선택
+        actualStartTime,
+        actualEndTime
+      );
       setSelectedTimes(newSelectedTimes);
       setCountClick(countClick + 1); // 2
     }
@@ -143,7 +159,6 @@ const TimeTable = ({
       current = nextTime;
     }
 
-    times.push(`${current} ~ ${end}`);
     return times;
   };
 

--- a/components/ticket/TicketDetail.tsx
+++ b/components/ticket/TicketDetail.tsx
@@ -1,15 +1,15 @@
-import { axiosInstance } from '@/api/auth/axios';
+import { authInstance, axiosInstance } from '@/api/auth/axios';
 import LocationModal from '@/components/popups/ticket/LocaltionModal';
 import DropdownMenu from '@/components/templates/ticket/DropdownMenu';
 import TicketOption from '@/components/templates/ticket/TicketOption';
 import RecommendedList from '@/components/ticket/RecommendedList';
 import Bar from '@/components/ui/Bar';
 import defaultPoster from '@/public/image/ticket/DefaultPoster.svg';
+import SettingsIcon from '@mui/icons-material/Settings';
 import dayjs from 'dayjs';
 import Image from 'next/image';
 import Link from 'next/link';
 import { useEffect, useState } from 'react';
-
 const apikey = process.env.NEXT_PUBLIC_KAKAOMAP_KEY;
 
 declare global {
@@ -35,6 +35,7 @@ const TicketDetail = ({ id }: TicketDetailProps) => {
   const [loc, setLoc] = useState('');
   const [statusText, setStatusText] = useState<string>('예매 마감');
   const [isLoading, setIsLoading] = useState(true);
+  const [isAdmin, setIsAdmin] = useState(false);
 
   const getTicketDetail = async (id: string) => {
     try {
@@ -81,9 +82,23 @@ const TicketDetail = ({ id }: TicketDetailProps) => {
     }
   };
 
+  const checkAdmin = async () => {
+    try {
+      const response = await authInstance.get('/user');
+      if (response.data.result.role === 'ADMIN') {
+        setIsAdmin(true);
+      } else {
+        setIsAdmin(false);
+      }
+    } catch (error) {
+      console.error('관리자 여부 확인 중 오류 발생:', error);
+    }
+  };
+
   useEffect(() => {
     setIsClient(true);
     setNowUrl(window.location.href);
+    checkAdmin(); // 어드민 여부 확인
   }, []);
 
   useEffect(() => {
@@ -242,18 +257,28 @@ const TicketDetail = ({ id }: TicketDetailProps) => {
           >
             {statusText}
           </div>
-          <div className="mt-5 pad:mt-4 gap-1 pad:gap-4 flex flex-row">
+          <div className="mt-5 pad:mt-4 gap-1 pad:gap-4 flex flex-row items-center">
             <p className="min-w-[190px] pad:w-[217px] pad:max-w-[217px] h-9 text-gray-90 font-semibold leading-9 text-[20px] pad:text-[24px] whitespace-nowrap">
               {ticketInfo?.title}
             </p>
-            <div onClick={copyUrl} className="flex flex-col justify-center">
-              <Image
-                src="/image/ticket/share.svg"
-                alt="share"
-                width={24}
-                height={24}
-                className="cursor-pointer h-5 w-5 pad:h-6 pad:w-6"
-              />
+            <div className="flex flex-row gap-2 items-center">
+              <div onClick={copyUrl} className="flex flex-col justify-center">
+                <Image
+                  src="/image/ticket/share.svg"
+                  alt="share"
+                  width={24}
+                  height={24}
+                  className="cursor-pointer h-5 w-5 pad:h-6 pad:w-6"
+                />
+              </div>
+              {isAdmin && (
+                <Link href={`/admin/performance/${id}`}>
+                  <SettingsIcon
+                    className="cursor-pointer text-gray-60"
+                    sx={{ fontSize: '28px' }}
+                  />
+                </Link>
+              )}
             </div>
           </div>
           <div className="flex flex-row mt-4 pad:mt-6 text-[16px] pad:text-[18px] leading-9 font-normal gap-6 h-7">


### PR DESCRIPTION
## 📝작업 내용
> 
1. 공연 정보 수정 페이지 추가
- '/ticket/[id]'에 버튼 추가
- ADMIN 권한인 사용자에게만 수정 버튼이 보입니다.

2. 동방 예약 에러 해결
- 수정 전) 두번째 블록 선택을 첫번째 블록 이전 시간으로 할 경우 런타임 에러 발생
- 수정 이후) 두번째 선택 블록의 위치 상관 없이 선택블록 채워지도록 수정

3. 동방 예약 CalendarUI 디자인 수정
- 날짜 선택 영역 border radius 수정

## 🔎코드 설명 및 참고 사항
> 
1. 공연 정보 수정 페이지 추가
- components/ticket/TicketDetail.tsx에서 checkAdmin 함수를 통해 권한 확인 후 조건부 렌더링 합니다.

2. 동방 예약 에러 해결
- compoents/reservation/TimeTable.tsx에서 handleTimeClick 함수 수정했습니다. 
- 두번째 선택한 블록과 첫번째 선택한 블록의 시작, 끝 시간을 각각 비교해서 처리합니다.

## 작업 사진
[ 공연정보수정 페이지 ]
![image](https://github.com/user-attachments/assets/af0adade-5532-4a88-8d96-5324673341b1)
![image](https://github.com/user-attachments/assets/b7b1dbb1-e588-475a-86a6-3c31c9b68550)


## 💬리뷰 요구사항
>

