### PR TITLE
Feat: 동아리방 예약 실시간 반영

### DIFF
--- a/app/(kahlua)/reservation/page.tsx
+++ b/app/(kahlua)/reservation/page.tsx
@@ -1,15 +1,15 @@
 'use client';
+import { authInstance } from '@/api/auth/axios';
 import Banner from '@/components/reservation/Banner';
 import CalendarUI from '@/components/reservation/CalendarUI';
 import ReservationForm from '@/components/reservation/ReservationForm';
 import RoomNotice from '@/components/reservation/RoomNotice';
 import TimeTable from '@/components/reservation/TimeTable';
-import React, { useEffect, useState } from 'react';
-import { authInstance } from '@/api/auth/axios';
-import SockJS from 'sockjs-client';
 import * as StompJs from '@stomp/stompjs';
 import Cookie from 'js-cookie';
 import { useRouter } from 'next/navigation';
+import { useEffect, useState } from 'react';
+import SockJS from 'sockjs-client';
 
 // 예약 요청 정보 타입
 export type Reservation = {
@@ -74,7 +74,21 @@ const page = () => {
         client.subscribe(
           `/topic/public/${reservation.reservationDate}`,
           (message) => {
-            console.log('메시지: ', JSON.parse(message.body));
+            const reservationData = JSON.parse(message.body);
+            console.log('새로운 예약 메시지:', reservationData);
+
+            // 시간 형식 확인 및 수정
+            if (!reservationData.startTime.includes(':00')) {
+              reservationData.startTime = `${reservationData.startTime}:00`;
+            }
+            if (!reservationData.endTime.includes(':00')) {
+              reservationData.endTime = `${reservationData.endTime}:00`;
+            }
+
+            setReservationsForDate((prevReservations) => [
+              ...prevReservations,
+              reservationData,
+            ]);
           }
         );
       }

--- a/app/(kahlua)/reservation/page.tsx
+++ b/app/(kahlua)/reservation/page.tsx
@@ -125,6 +125,12 @@ const page = () => {
       ...prev,
       [key]: value,
     }));
+
+    // 날짜가 변경될 때 예약 목록 초기화
+    if (key === 'reservationDate') {
+      setReservationsForDate([]); // 예약 목록 초기화
+      fetchReservationsForDate(value);
+    }
   };
 
   // 날짜별 예약 내역 조회 (http 요청)
@@ -198,9 +204,6 @@ const page = () => {
       <CalendarUI
         onChange={(key, value) => {
           handleChange(key, value);
-          if (key === 'reservationDate') {
-            fetchReservationsForDate(value);
-          }
         }}
       />
       <TimeTable

--- a/components/reservation/TimeTable.tsx
+++ b/components/reservation/TimeTable.tsx
@@ -63,10 +63,15 @@ const TimeTable = ({
     const formattedStartTime = `${startTime}:00`;
     const formattedEndTime = `${endTime}:00`;
 
-    const reservation = reservationsForDate.find(
-      (res) =>
-        res.startTime <= formattedStartTime && res.endTime >= formattedEndTime
-    );
+    const reservation = reservationsForDate.find((res) => {
+      // 시간이 겹치는지 확인
+      return (
+        (res.startTime <= formattedStartTime &&
+          res.endTime > formattedStartTime) || // 예약이 슬롯 시작 전에 시작
+        (res.startTime < formattedEndTime && res.endTime >= formattedEndTime) || // 예약이 슬롯 종료 후에 끝
+        (res.startTime >= formattedStartTime && res.endTime <= formattedEndTime) // 예약이 슬롯 안에 완전히 포함
+      );
+    });
     return reservation ? reservation.clubroomUsername : null;
   };
   const getReservedByEmail = (startTime: string, endTime: string) => {


### PR DESCRIPTION
## 📝작업 내용
> 
1. 동일한 날짜를 구독하는 사용자는 서로의 예약 정보가 실시간으로 테이블에 반영됩니다. 따라서 중복된 예약을 방지할 수 있습니다.
2. 날짜 변경 시 이전 날짜 예약정보가 깜빡이며 보이는 이슈 해결했습니다.


## 🔎코드 설명 및 참고 사항
> 
1번 관련) 웹소켓 연결 중 서버에서 보내는 message를 받아 실시간으로 타임테이블 UI에 반영합니다.
2번 관련) 예약 정보를 받아오는 시점 이전에 상태 정보를 초기화하여 깜빡임을 방지합니다.

## 💬리뷰 요구사항
>