### PR TITLE
Feat: 예약자명 실시간 반영

### DIFF
--- a/app/(kahlua)/reservation/page.tsx
+++ b/app/(kahlua)/reservation/page.tsx
@@ -85,10 +85,20 @@ const page = () => {
               reservationData.endTime = `${reservationData.endTime}:00`;
             }
 
-            setReservationsForDate((prevReservations) => [
-              ...prevReservations,
-              reservationData,
-            ]);
+            setReservationsForDate((prevReservations) => {
+              // 동일 시간대 예약이 있으면 제거
+              const filtered = prevReservations.filter(
+                (r) =>
+                  !(
+                    r.startTime === reservationData.startTime &&
+                    r.endTime === reservationData.endTime &&
+                    r.reservationDate === reservationData.reservationDate
+                  )
+              );
+
+              // 새 데이터 추가
+              return [...filtered, reservationData];
+            });
           }
         );
       }


### PR DESCRIPTION
## 📝작업 내용
동일한 날짜를 구독하는 사용지는 실시간으로 예약 정보의 **예약자명**을 타임테이블 ui에 반영하게 됩니다.

## 🔎코드 설명 및 참고 사항

**수정 이전:** 예약 시간대 선택 이후 생성된 예약 정보 데이터는 예약자명이 null이므로 예약 확정 이후에도 ui에 예약자명이 반영되지 않았습니다.

**수정 이후:** 예약 확정 이후 받아오는 message에서 날짜를 비교하여, 동일하다면 기존 예약 데이터를 삭제하고 완성된 예약정보를 새로 추가합니다. 따라서 예약자명을 타임테이블에 실시간으로 렌더링할 수 있습니다.
