### PR TITLE
Refactor: 홈 티켓 컴포넌트 최신 공연 API 받아오도록 추가

### DIFF
--- a/api/performance/performance.ts
+++ b/api/performance/performance.ts
@@ -1,0 +1,13 @@
+import { axiosInstance } from '@/api/auth/axios';
+import { PerformanceResponse } from '@/types/performace';
+
+export const fetchLatestPerformance =
+  async (): Promise<PerformanceResponse | null> => {
+    try {
+      const res = await axiosInstance.get('/performances/latest-performance');
+      return res.data.result.performanceResponse;
+    } catch (err) {
+      console.error('공연 정보를 불러오지 못했습니다:', err);
+      return null;
+    }
+  };

--- a/components/main/Ticket.tsx
+++ b/components/main/Ticket.tsx
@@ -1,16 +1,37 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
 import { TicketIntroPad, TicketIntroPhone } from './TicketIntro';
 
+import { PerformanceResponse } from '@/types/performace';
+import { fetchLatestPerformance } from '@/api/performance/performance';
+
 const Ticket = () => {
+  const [performance, setPerformance] = useState<PerformanceResponse | null>(
+    null
+  );
+
+  useEffect(() => {
+    const loadPerformance = async () => {
+      const data = await fetchLatestPerformance();
+      if (data) setPerformance(data);
+    };
+    loadPerformance();
+  }, []);
+
+  if (!performance) return null;
+
   return (
     <div className="flex flex-col w-full max-pad:max-w-[500px] max-pad:px-[16px] pad:w-[786px] dt:w-[1200px] h-auto items-center mt-[48px] mb-[80px] pad:mt-[120px] pad:mb-[240px] ">
       <div className="flex justify-start w-full font-mustica text-[24px] pad:text-[48px] font-semibold">
         TICKET
       </div>
 
-      {/* ticket Introduction */}
-      <TicketIntroPad className="max-pad:hidden" />
-      <TicketIntroPhone className="pad:hidden" />
+      <TicketIntroPad className="max-pad:hidden" performance={performance} />
+      <TicketIntroPhone className="pad:hidden" performance={performance} />
     </div>
   );
 };
+
 export default Ticket;

--- a/components/main/TicketIntro.tsx
+++ b/components/main/TicketIntro.tsx
@@ -1,22 +1,29 @@
 import Image from 'next/image';
-
 import React from 'react';
 
 import { TicketInfo, TicketButton } from './TicketInfo';
-import { information } from '@/components/data/Information';
+import { formatDate, formatDateTime } from '@/components/util/formatDate';
+import { PerformanceResponse } from '@/types/performace';
 
 interface TicketIntroProps {
-  className: string;
+  className?: string;
+  performance: PerformanceResponse;
 }
 
-const TicketIntroPad = ({ className }: TicketIntroProps) => {
+export const TicketIntroPad = ({
+  className = '',
+  performance,
+}: TicketIntroProps) => {
+  const day = formatDate(performance.booking_end_date);
+  const time = formatDateTime(performance.date_time);
+
   return (
     <div
       className={`flex flex-row w-full h-auto mt-[32px] gap-[32px] ${className}`}
     >
       <div className="flex shrink-0 relative rounded-[16px] w-[264px] h-[351px] pad:w-[246px] pad:h-[329px] dt:w-[282px] dt:h-[377px]">
         <Image
-          src="/image/ticket/Poster_202503.avif"
+          src={performance.poster_image_url}
           alt="poster"
           fill
           sizes="100vw"
@@ -30,17 +37,23 @@ const TicketIntroPad = ({ className }: TicketIntroProps) => {
           홈페이지에서 간편하게 예매하세요
         </p>
         <TicketInfo
-          day={information.dayForString}
-          performanceName={information.title}
-          place={information.location}
-          time={information.dateForString}
+          day={day}
+          performanceName={performance.title}
+          place={performance.venue}
+          time={time}
         />
       </div>
     </div>
   );
 };
 
-const TicketIntroPhone = ({ className }: TicketIntroProps) => {
+export const TicketIntroPhone = ({
+  className = '',
+  performance,
+}: TicketIntroProps) => {
+  const day = formatDate(performance.booking_end_date);
+  const time = formatDateTime(performance.date_time);
+
   return (
     <div
       className={`flex flex-col justify-center items-center w-full h-full ${className}`}
@@ -51,21 +64,19 @@ const TicketIntroPhone = ({ className }: TicketIntroProps) => {
           <div className="flex h-[105px] w-[120px] bg-primary-50 z-0" />
           <div className="flex h-[262px] w-full bg-primary-50 rounded-b-[32px] rounded-tl-[32px] z-0">
             <TicketInfo
-              day={information.dayForString}
-              performanceName={information.title}
-              place={information.location}
-              time={information.dateForString}
+              day={day}
+              performanceName={performance.title}
+              place={performance.venue}
+              time={time}
             />
           </div>
         </div>
 
         <div className="flex shrink-0 absolute top-0 rounded-[16px] w-[264px] h-[351px]">
-          <Image src="/image/ticket/Poster_202503.avif" alt="poster" fill />
+          <Image src={performance.poster_image_url} alt="poster" fill />
         </div>
       </div>
       <TicketButton className="flex mt-[32px]" />
     </div>
   );
 };
-
-export { TicketIntroPad, TicketIntroPhone };

--- a/components/util/formatDate.ts
+++ b/components/util/formatDate.ts
@@ -5,3 +5,12 @@ export const formatDate = (dateString: string) => {
   const day = String(date.getDate()).padStart(2, '0');
   return `${year}.${month}.${day}`;
 };
+
+export const formatDateTime = (dateString: string) => {
+  const date = new Date(dateString);
+  const year = date.getFullYear();
+  const month = date.getMonth() + 1;
+  const day = date.getDate();
+  const hour = date.getHours();
+  return `${year}년 ${month}월 ${day}일 ${hour}시`;
+};

--- a/types/performace.ts
+++ b/types/performace.ts
@@ -1,0 +1,16 @@
+export interface PerformanceResponse {
+  id: number;
+  poster_image_url: string;
+  youtube_url: string;
+  title: string;
+  content: string;
+  venue: string;
+  address: string;
+  date_time: string;
+  freshman_price: string;
+  freshman_max_purchase: number;
+  general_price: string;
+  general_max_purchase: number;
+  booking_start_date: string;
+  booking_end_date: string;
+}


### PR DESCRIPTION
## 📝작업 내용
> 홈 티켓 컴포넌트에 최신 공연 API 연동을 추가했습니다.

## 🔎코드 설명 및 참고 사항
> 공연 관련 응답 타입은 types/performance.ts에 정리해두었고,
최신 공연 정보를 가져오는 API는 apis/performance/performance.ts로 분리해두었으니
티켓 페이지에서도 최신 공연 API를 가져올 때 공통으로 활용해 주세요. @boogiewooki02 
로그인 브랜치에서 작업해서 머쓱하네요