### PR TITLE
Fix: 최대 티켓 수 api로 연결 및 라벨 포맷

### DIFF
--- a/components/ui/DropDownBox.tsx
+++ b/components/ui/DropDownBox.tsx
@@ -2,7 +2,6 @@ import Image from 'next/image';
 import { useState, useEffect, useRef } from 'react';
 import TicketDetails from './TicketDetails';
 import clsx from 'clsx';
-import dayjs from 'dayjs';
 import { formatDateTimeMinute } from '../util/formatDate';
 
 interface Option {
@@ -35,13 +34,11 @@ const DropDownBox: React.FC<DropDownBoxProps> = ({
   const dateOptions: Option[] = data?.performance_start_time
     ? [
         {
-          value: data.performance_start_time, // 원본(UTC)
-          label: formatDateTimeMinute(data.performance_start_time), // 표시용(KST)
+          value: formatDateTimeMinute(data.performance_start_time),
+          label: formatDateTimeMinute(data.performance_start_time),
         },
       ]
     : [];
-
-  console.log(data);
 
   const ticketOptions: Option[] = [
     // {
@@ -101,6 +98,7 @@ const DropDownBox: React.FC<DropDownBoxProps> = ({
     >
       {selectedTicket ? (
         <TicketDetails
+          maxTicket={data.general_max_purchase}
           ticketType={selectedTicket}
           onClick={handleTicketDetailsClick}
           member={member}

--- a/components/ui/TicketDetails.tsx
+++ b/components/ui/TicketDetails.tsx
@@ -5,9 +5,10 @@ const TicketDetails: React.FC<{
   ticketType: string;
   onClick: (event: React.MouseEvent) => void;
   member: number;
+  maxTicket: number;
   setMember: React.Dispatch<React.SetStateAction<number>>;
-}> = ({ ticketType, onClick, member, setMember }) => {
-  const max = ticketType === '신입생 티켓' ? 1 : 5;
+}> = ({ ticketType, onClick, member, setMember, maxTicket }) => {
+  const max = ticketType === '신입생 티켓' ? 1 : maxTicket;
   const min = 1;
   const ticket = ticketType === '신입생 티켓' ? 'freshman' : 'general';
 


### PR DESCRIPTION
## 📝 작업 내용
> 
- 일반 예매 최대 티켓 수 하드코딩 -> api 연동 코드로 변경
- 드롭다운 선택 시 라벨 렌더링 오류 해결

