### PR TITLE
Fix: useMemo로 today 기준 고정

### DIFF
--- a/components/reservation/CalendarUI.tsx
+++ b/components/reservation/CalendarUI.tsx
@@ -1,10 +1,11 @@
 import { useMemo, useState } from 'react';
 import Calendar from 'react-calendar';
 
+import Modal from '@/components/ui/Modal';
 import { ReservationRequest } from '@/types/reservation';
 
 import 'react-calendar/dist/Calendar.css';
-import Modal from '../ui/Modal';
+
 import './CalendarUI.css';
 
 type ValuePiece = Date | null;

--- a/components/reservation/CalendarUI.tsx
+++ b/components/reservation/CalendarUI.tsx
@@ -1,13 +1,12 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import Calendar from 'react-calendar';
 
 import { ReservationRequest } from '@/types/reservation';
 
-import 'react-calendar/dist/Calendar.css'; // 기본 스타일
+import 'react-calendar/dist/Calendar.css';
 import Modal from '../ui/Modal';
 import './CalendarUI.css';
 
-// react-calnedar에서 요구하는 타입 형식 (변경 x)
 type ValuePiece = Date | null;
 type Value = ValuePiece | [ValuePiece, ValuePiece];
 
@@ -20,7 +19,19 @@ const CalendarUI = ({ onChange }: CalendarProps) => {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [tempDate, setTempDate] = useState<Date | null>(null);
 
-  const handleDateChange = async (newValue: Value) => {
+  const [todayStart] = useState(() => {
+    const now = new Date();
+    return new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  });
+
+  const twoWeeksFromToday = useMemo(() => {
+    if (!todayStart) return null;
+    const d = new Date(todayStart);
+    d.setDate(d.getDate() + 14);
+    return d;
+  }, [todayStart]);
+
+  const handleDateChange = (newValue: Value) => {
     if (newValue instanceof Date) {
       const day = newValue.getDay();
 
@@ -35,8 +46,7 @@ const CalendarUI = ({ onChange }: CalendarProps) => {
       const mm = String(newValue.getMonth() + 1).padStart(2, '0');
       const dd = String(newValue.getDate()).padStart(2, '0');
 
-      const dateString = `${yyyy}-${mm}-${dd}`;
-      onChange('reservationDate', dateString);
+      onChange('reservationDate', `${yyyy}-${mm}-${dd}`);
     }
   };
 
@@ -47,8 +57,7 @@ const CalendarUI = ({ onChange }: CalendarProps) => {
       const mm = String(tempDate.getMonth() + 1).padStart(2, '0');
       const dd = String(tempDate.getDate()).padStart(2, '0');
 
-      const dateString = `${yyyy}-${mm}-${dd}`;
-      onChange('reservationDate', dateString);
+      onChange('reservationDate', `${yyyy}-${mm}-${dd}`);
     }
 
     setIsModalOpen(false);
@@ -56,29 +65,16 @@ const CalendarUI = ({ onChange }: CalendarProps) => {
   };
 
   const isSelectable = (date: Date) => {
-    const today = new Date();
+    if (!todayStart || !twoWeeksFromToday) return false;
 
-    // 날짜 비교를 위해 양쪽 모두 현지 시간대의 00:00:00으로 설정
     const compareDate = new Date(
       date.getFullYear(),
       date.getMonth(),
       date.getDate()
     );
-    const compareToday = new Date(
-      today.getFullYear(),
-      today.getMonth(),
-      today.getDate()
-    );
-
     const day = date.getDay();
 
-    const twoWeeksFromToday = new Date(compareToday);
-    twoWeeksFromToday.setDate(compareToday.getDate() + 14);
-
-    // 오늘 이전 날짜는 비활성화
-    if (compareDate < compareToday) return false;
-
-    // 오늘 기준 2주 이후 날짜는 비활성화
+    if (compareDate < todayStart) return false;
     if (compareDate > twoWeeksFromToday) return false;
 
     // 월, 목, 토, 일요일만 선택 가능 (2025년 2학기)


### PR DESCRIPTION
## 📝작업 내용
> 달 이동 또는 새로고침 시 동방 예약 가능 날짜가 달라지던 문제를 수정했습니다.
오늘 날짜를 새로 계산하지 않고 useMemo로 고정하여 날짜 기준이 흔들리지 않도록 개선했습니다.
